### PR TITLE
fix: @lion-frame スコープを @lionframe に統一

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -376,7 +376,7 @@ return {
 
 ```json
 {
-  "name": "@lion-frame/mcp-{module}",
+  "name": "@lionframe/mcp-{module}",
   "version": "1.0.0",
   "type": "module",
   "main": "dist/index.js",

--- a/.claude/skills/deployment/SKILL.md
+++ b/.claude/skills/deployment/SKILL.md
@@ -40,8 +40,8 @@ openssl rand -base64 48
 pnpm install
 
 # データベースを初期化
-pnpm --filter @lion-frame/web exec prisma db push
-pnpm --filter @lion-frame/web run db:seed
+pnpm --filter @lionframe/web exec prisma db push
+pnpm --filter @lionframe/web run db:seed
 
 # 開発サーバ起動
 pnpm dev

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -316,7 +316,7 @@ npm run test -- --testPathPatterns="api/ai"
 npm run test -- --watch
 
 # 単一ファイル
-pnpm --filter @lion-frame/web test -- __tests__/lib/modules/access-control.test.ts
+pnpm --filter @lionframe/web test -- __tests__/lib/modules/access-control.test.ts
 ```
 
 ## テスト追加の判断基準

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,9 @@ pnpm build                 # 全アプリのビルド
 pnpm test                  # 全アプリのテスト
 
 # Webアプリのみ
-pnpm --filter @lion-frame/web dev
-pnpm --filter @lion-frame/web build
-pnpm --filter @lion-frame/web test
+pnpm --filter @lionframe/web dev
+pnpm --filter @lionframe/web build
+pnpm --filter @lionframe/web test
 
 # Prisma（apps/web/で実行）
 cd apps/web && npx prisma studio

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lion-frame/web",
+  "name": "@lionframe/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/mcp-servers/organization/package.json
+++ b/mcp-servers/organization/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lion-frame/mcp-organization",
+  "name": "@lionframe/mcp-organization",
   "version": "1.0.0",
   "private": true,
   "description": "MCP server for organization data (read-only)",


### PR DESCRIPTION
## Summary
- npmパッケージスコープの表記揺れ（`@lion-frame/` vs `@lionframe/`）を `@lionframe/` に統一
- `@lion-frame/web` → `@lionframe/web`、`@lion-frame/mcp-organization` → `@lionframe/mcp-organization`
- ドキュメント内の `pnpm --filter` コマンド例も合わせて修正

## 背景
既存のパッケージで `@lionframe/module-types`、`@lionframe/addon-ai-playground` 等は
ハイフンなしの `@lionframe` スコープを使用していますが、`apps/web` と `mcp-servers/organization` のみ
`@lion-frame`（ハイフンあり）となっており不統一でした。

## 変更ファイル
- `apps/web/package.json` — パッケージ名
- `mcp-servers/organization/package.json` — パッケージ名
- `CLAUDE.md` — filterコマンド例
- `.claude/skills/architecture/SKILL.md` — MCPテンプレート例
- `.claude/skills/deployment/SKILL.md` — filterコマンド例
- `.claude/skills/testing/SKILL.md` — filterコマンド例

## Test plan
- [ ] `pnpm install` が正常に完了すること
- [ ] `pnpm --filter @lionframe/web dev` でWebアプリが起動すること
- [ ] `pnpm build` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)