### PR TITLE
test: OIDC エンドポイントの API 契約テストを追加

### DIFF
--- a/apps/web/__tests__/api/oidc/authorize.test.ts
+++ b/apps/web/__tests__/api/oidc/authorize.test.ts
@@ -1,0 +1,429 @@
+export {};
+
+/**
+ * OIDC Authorize エンドポイント契約テスト
+ *
+ * 検証対象:
+ * - client_id / redirect_uri / response_type / PKCE / scope の各検証
+ * - redirect_uri 未検証段階のエラーは JSON、検証済み以降はクエリ付き 302 redirect
+ * - 未ログイン時は AuthRequest を永続化して /login?callbackUrl=... へ 302 + cookie
+ * - allowedRoles 違反で access_denied redirect + 監査ログ
+ * - autoApprove / 既存同意で認可コード発行 + redirect_uri へ 302
+ * - 通常フローでは /oidc/consent へ 302 + cookie set
+ */
+
+// ============================================================
+// Mocks
+// ============================================================
+
+const mockAuditLog = jest.fn();
+jest.mock("@/lib/services/audit-service", () => ({
+  AuditService: { log: mockAuditLog },
+}));
+
+const mockAuth = jest.fn();
+jest.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+jest.mock("jose", () => ({
+  jwtVerify: jest.fn(),
+  SignJWT: class {
+    setProtectedHeader() { return this; }
+    setIssuer() { return this; }
+    setSubject() { return this; }
+    setAudience() { return this; }
+    setIssuedAt() { return this; }
+    setExpirationTime() { return this; }
+    setJti() { return this; }
+    sign() { return Promise.resolve("signed.jwt.token"); }
+  },
+}));
+
+jest.mock("@/lib/services/oidc/keys", () => ({
+  getActiveSigningKey: jest.fn(() =>
+    Promise.resolve({ kid: "k1", privateKey: "p", publicKey: "q", publicJwk: {} }),
+  ),
+  findKeyByKid: jest.fn(),
+  getPublicJwks: jest.fn(),
+}));
+
+const mockPrisma = {
+  oIDCClient: { findUnique: jest.fn() },
+  oIDCAuthRequest: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    delete: jest.fn().mockResolvedValue(undefined),
+  },
+  oIDCConsent: {
+    findUnique: jest.fn(),
+    upsert: jest.fn().mockResolvedValue(undefined),
+  },
+  oIDCAuthCode: {
+    create: jest.fn(),
+  },
+};
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+jest.mock("@/lib/services/rate-limiter", () => ({
+  checkRateLimit: jest.fn(() => ({ allowed: true, remaining: 100, resetMs: 60000 })),
+  getClientIp: jest.fn(() => "127.0.0.1"),
+}));
+
+beforeAll(() => {
+  process.env.OIDC_ISSUER = "http://localhost:3000";
+  process.env.AUTH_SECRET = "test-auth-secret-for-cookie-signer";
+});
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function validClient(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "client_row_1",
+    clientId: "client_public_abc",
+    clientSecretHash: "hash",
+    name: "Test Client",
+    description: null,
+    redirectUris: ["https://rp.example.lan/callback"],
+    allowedScopes: ["openid", "profile", "email"],
+    allowedRoles: ["USER", "MANAGER", "EXECUTIVE", "ADMIN"],
+    enabled: true,
+    autoApprove: false,
+    createdBy: "admin_1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function userSession(role = "USER") {
+  return {
+    user: {
+      id: "user_1",
+      email: "u@example.com",
+      role,
+      language: "ja",
+      twoFactorEnabled: false,
+      mustChangePassword: false,
+    },
+    expires: "2099-01-01",
+  };
+}
+
+function buildAuthorizeUrl(params: Record<string, string>): string {
+  const base = "http://localhost:3000/api/oidc/authorize";
+  const qs = new URLSearchParams(params).toString();
+  return qs ? `${base}?${qs}` : base;
+}
+
+function makeRequest(
+  urlOrParams: string | Record<string, string>,
+  cookies: string[] = [],
+): Request {
+  const url =
+    typeof urlOrParams === "string"
+      ? urlOrParams
+      : buildAuthorizeUrl(urlOrParams);
+  const headers: Record<string, string> = {};
+  if (cookies.length > 0) headers.cookie = cookies.join("; ");
+  return new Request(url, { method: "GET", headers });
+}
+
+const validParams = {
+  client_id: "client_public_abc",
+  redirect_uri: "https://rp.example.lan/callback",
+  response_type: "code",
+  scope: "openid profile email",
+  state: "state123",
+  nonce: "nonce123",
+  code_challenge: "x".repeat(43), // 任意の challenge 文字列
+  code_challenge_method: "S256",
+};
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("Authorize エンドポイント契約", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルト: AuthRequest は新規作成される
+    mockPrisma.oIDCAuthRequest.create.mockImplementation(
+      (args: { data: Record<string, unknown> }) => ({
+        id: "authreq_1",
+        ...args.data,
+      }),
+    );
+    // デフォルト: 既存 AuthRequest は存在しない
+    mockPrisma.oIDCAuthRequest.findUnique.mockResolvedValue(null);
+    // デフォルト: Consent も存在しない
+    mockPrisma.oIDCConsent.findUnique.mockResolvedValue(null);
+    // authCode 発行
+    mockPrisma.oIDCAuthCode.create.mockImplementation(
+      (args: { data: Record<string, unknown> }) => ({
+        id: args.data.id as string,
+        ...args.data,
+      }),
+    );
+  });
+
+  // ------------------ 初期検証: JSON エラー ------------------
+
+  it("client_id なしで 400 invalid_request (JSON)", async () => {
+    const { client_id, ...rest } = validParams;
+    void client_id;
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(rest));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("不明な client_id で 400 invalid_client (JSON)", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(null);
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("クライアント enabled=false で 400 invalid_client", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(
+      validClient({ enabled: false }),
+    );
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("redirect_uri 不一致で 400 invalid_request (JSON)", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(
+      makeRequest({
+        ...validParams,
+        redirect_uri: "https://evil.example.lan/callback",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_request");
+    expect(body.error_description).toMatch(/redirect_uri/);
+  });
+
+  // ------------------ redirect_uri 検証後: 302 redirect エラー ------------------
+
+  it("response_type != code で redirect_uri に unsupported_response_type を 302 redirect", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(
+      makeRequest({ ...validParams, response_type: "token" }),
+    );
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location") as string);
+    expect(location.searchParams.get("error")).toBe(
+      "unsupported_response_type",
+    );
+    expect(location.searchParams.get("state")).toBe("state123");
+  });
+
+  it("code_challenge 欠如で invalid_request を redirect", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const { code_challenge, ...rest } = validParams;
+    void code_challenge;
+    const res = await GET(makeRequest(rest));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.searchParams.get("error")).toBe("invalid_request");
+    expect(loc.searchParams.get("error_description")).toMatch(/code_challenge/);
+  });
+
+  it("code_challenge_method != S256 で invalid_request を redirect", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(
+      makeRequest({ ...validParams, code_challenge_method: "plain" }),
+    );
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.searchParams.get("error")).toBe("invalid_request");
+  });
+
+  it("openid scope 欠如で invalid_scope を redirect", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(
+      makeRequest({ ...validParams, scope: "profile email" }),
+    );
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.searchParams.get("error")).toBe("invalid_scope");
+  });
+
+  it("許可外 scope で invalid_scope を redirect", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(
+      validClient({ allowedScopes: ["openid", "email"] }), // profile を外している
+    );
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.searchParams.get("error")).toBe("invalid_scope");
+    expect(loc.searchParams.get("error_description")).toMatch(/profile/);
+  });
+
+  // ------------------ セッション・同意フロー ------------------
+
+  it("未ログイン時: AuthRequest を作成し /login?callbackUrl=... へ 302 + cookie set", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(null);
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.pathname).toBe("/login");
+    expect(loc.searchParams.get("callbackUrl")).toMatch(
+      /\/api\/oidc\/authorize\?resume=/,
+    );
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=/);
+    expect(mockPrisma.oIDCAuthRequest.create).toHaveBeenCalled();
+  });
+
+  it("allowedRoles 違反で access_denied redirect + 監査ログ", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(
+      validClient({ allowedRoles: ["ADMIN"] }),
+    );
+    mockAuth.mockResolvedValue(userSession("USER"));
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.searchParams.get("error")).toBe("access_denied");
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_AUTHORIZE_DENIED",
+        category: "OIDC",
+        userId: "user_1",
+      }),
+    );
+  });
+
+  it("autoApprove=true のクライアントで認可コードを発行 + redirect_uri へ 302", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(
+      validClient({ autoApprove: true }),
+    );
+    mockAuth.mockResolvedValue(userSession("USER"));
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.origin + loc.pathname).toBe(
+      "https://rp.example.lan/callback",
+    );
+    expect(loc.searchParams.get("code")).toMatch(/^code_/);
+    expect(loc.searchParams.get("state")).toBe("state123");
+
+    // cookie クリア
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=;/);
+
+    expect(mockPrisma.oIDCConsent.upsert).toHaveBeenCalled();
+    expect(mockPrisma.oIDCAuthCode.create).toHaveBeenCalled();
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_CONSENT_GRANT",
+        category: "OIDC",
+        details: expect.objectContaining({ auto: true }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_AUTHORIZE",
+        category: "OIDC",
+      }),
+    );
+  });
+
+  it("既存 Consent が要求 scope を包含する場合も code 発行", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(userSession("USER"));
+    mockPrisma.oIDCConsent.findUnique.mockResolvedValue({
+      id: "consent_1",
+      scope: "openid profile email",
+      revokedAt: null,
+    });
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.origin + loc.pathname).toBe(
+      "https://rp.example.lan/callback",
+    );
+    expect(loc.searchParams.get("code")).toMatch(/^code_/);
+  });
+
+  it("既存 Consent が要求 scope を包含しない場合は /oidc/consent へ", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(userSession("USER"));
+    mockPrisma.oIDCConsent.findUnique.mockResolvedValue({
+      id: "consent_1",
+      scope: "openid", // profile/email が不足
+      revokedAt: null,
+    });
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.pathname).toBe("/oidc/consent");
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=/);
+    expect(mockPrisma.oIDCAuthRequest.create).toHaveBeenCalled();
+  });
+
+  it("通常フロー: ログイン済み・同意なしで /oidc/consent へ 302 + cookie set", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(userSession("USER"));
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.pathname).toBe("/oidc/consent");
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=/);
+    expect(mockPrisma.oIDCAuthRequest.create).toHaveBeenCalled();
+    // code は発行しない
+    expect(mockPrisma.oIDCAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  // ------------------ rate limit ------------------
+
+  it("rate limit 超過で 429", async () => {
+    const rl = require("@/lib/services/rate-limiter");
+    rl.checkRateLimit.mockReturnValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetMs: 1000,
+    });
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/web/__tests__/api/oidc/consent.test.ts
+++ b/apps/web/__tests__/api/oidc/consent.test.ts
@@ -1,0 +1,279 @@
+export {};
+
+/**
+ * OIDC Consent エンドポイント (POST /api/oidc/consent) 契約テスト
+ *
+ * 検証対象:
+ * - 未ログインで 401
+ * - handle 欠如 / 期限切れで 400
+ * - approve=false で access_denied redirect + AuthRequest 削除 + 監査ログ
+ * - allowedRoles 違反で access_denied
+ * - 成功: Consent upsert + 認可コード発行 + OIDC_CONSENT_GRANT/OIDC_AUTHORIZE 監査ログ + cookie クリア
+ */
+
+// ============================================================
+// Mocks
+// ============================================================
+
+const mockAuditLog = jest.fn();
+jest.mock("@/lib/services/audit-service", () => ({
+  AuditService: { log: mockAuditLog },
+}));
+
+const mockAuth = jest.fn();
+jest.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+jest.mock("jose", () => ({
+  jwtVerify: jest.fn(),
+  SignJWT: class {
+    setProtectedHeader() { return this; }
+    setIssuer() { return this; }
+    setSubject() { return this; }
+    setAudience() { return this; }
+    setIssuedAt() { return this; }
+    setExpirationTime() { return this; }
+    setJti() { return this; }
+    sign() { return Promise.resolve("signed"); }
+  },
+}));
+
+jest.mock("@/lib/services/oidc/keys", () => ({
+  getActiveSigningKey: jest.fn(),
+  findKeyByKid: jest.fn(),
+  getPublicJwks: jest.fn(),
+}));
+
+const mockPrisma = {
+  oIDCAuthRequest: {
+    findUnique: jest.fn(),
+    delete: jest.fn().mockResolvedValue(undefined),
+  },
+  oIDCConsent: {
+    upsert: jest.fn().mockResolvedValue(undefined),
+  },
+  oIDCAuthCode: {
+    create: jest.fn().mockImplementation(
+      (args: { data: Record<string, unknown> }) => ({
+        id: args.data.id as string,
+        ...args.data,
+      }),
+    ),
+  },
+};
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+jest.mock("@/lib/services/rate-limiter", () => ({
+  checkRateLimit: jest.fn(() => ({ allowed: true, remaining: 100, resetMs: 60000 })),
+  getClientIp: jest.fn(() => "127.0.0.1"),
+}));
+
+beforeAll(() => {
+  process.env.OIDC_ISSUER = "http://localhost:3000";
+  process.env.AUTH_SECRET = "test-secret";
+});
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function userSession(role = "USER") {
+  return {
+    user: {
+      id: "user_1",
+      email: "u@example.com",
+      role,
+      twoFactorEnabled: false,
+      mustChangePassword: false,
+    },
+    expires: "2099-01-01",
+  };
+}
+
+function validAuthRequest(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "authreq_1",
+    clientId: "client_row_1",
+    redirectUri: "https://rp.example.lan/callback",
+    scope: "openid profile email",
+    state: "state_123",
+    nonce: "nonce_123",
+    codeChallenge: "c".repeat(43),
+    codeChallengeMethod: "S256",
+    responseType: "code",
+    expiresAt: new Date(Date.now() + 60_000),
+    createdAt: new Date(),
+    client: {
+      id: "client_row_1",
+      clientId: "client_public_abc",
+      allowedRoles: ["USER", "MANAGER", "EXECUTIVE", "ADMIN"],
+    },
+    ...overrides,
+  };
+}
+
+async function makeRequest(
+  body: { handle?: string; approve?: boolean },
+  options: { signedHandle?: string } = {},
+): Promise<Request> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (options.signedHandle !== undefined) {
+    headers.cookie = `oidc_auth_req=${encodeURIComponent(options.signedHandle)}`;
+  }
+  return new Request("http://localhost:3000/api/oidc/consent", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function signedCookieFor(handle: string): Promise<string> {
+  const { signValue } = require("@/lib/services/cookie-signer");
+  return signValue(handle);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("Consent POST エンドポイント契約", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("未ログインで 401", async () => {
+    mockAuth.mockResolvedValue(null);
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(await makeRequest({ handle: "x", approve: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("handle 欠如で 400 invalid_request", async () => {
+    mockAuth.mockResolvedValue(userSession());
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(await makeRequest({ approve: true }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("期限切れ AuthRequest で 400 invalid_request", async () => {
+    mockAuth.mockResolvedValue(userSession());
+    const signed = await signedCookieFor("authreq_1");
+    mockPrisma.oIDCAuthRequest.findUnique.mockResolvedValue(
+      validAuthRequest({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+    // getAuthRequest 内部で削除してから null を返す挙動に任せる
+
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(
+      await makeRequest({ approve: true }, { signedHandle: signed }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("approve=false で access_denied redirect + AuthRequest 削除 + OIDC_AUTHORIZE_DENIED 監査ログ", async () => {
+    mockAuth.mockResolvedValue(userSession());
+    const signed = await signedCookieFor("authreq_1");
+    mockPrisma.oIDCAuthRequest.findUnique.mockResolvedValue(validAuthRequest());
+
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(
+      await makeRequest({ approve: false }, { signedHandle: signed }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.redirectTo).toMatch(/^https:\/\/rp\.example\.lan\/callback/);
+    const loc = new URL(body.redirectTo);
+    expect(loc.searchParams.get("error")).toBe("access_denied");
+    expect(loc.searchParams.get("state")).toBe("state_123");
+
+    // cookie クリア
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=;/);
+
+    // AuthRequest 削除
+    expect(mockPrisma.oIDCAuthRequest.delete).toHaveBeenCalledWith({
+      where: { id: "authreq_1" },
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_AUTHORIZE_DENIED",
+        category: "OIDC",
+        details: expect.objectContaining({ reason: "user_denied" }),
+      }),
+    );
+    // code は発行されない
+    expect(mockPrisma.oIDCAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  it("allowedRoles 違反で access_denied + AuthRequest 削除（authorize 後にロール変更されたケース）", async () => {
+    mockAuth.mockResolvedValue(userSession("USER"));
+    const signed = await signedCookieFor("authreq_1");
+    mockPrisma.oIDCAuthRequest.findUnique.mockResolvedValue(
+      validAuthRequest({
+        client: {
+          id: "client_row_1",
+          clientId: "client_public_abc",
+          allowedRoles: ["ADMIN"], // USER は弾かれる
+        },
+      }),
+    );
+
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(
+      await makeRequest({ approve: true }, { signedHandle: signed }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const loc = new URL(body.redirectTo);
+    expect(loc.searchParams.get("error")).toBe("access_denied");
+    expect(mockPrisma.oIDCAuthRequest.delete).toHaveBeenCalled();
+    expect(mockPrisma.oIDCAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  it("成功: Consent upsert + 認可コード発行 + 監査ログ + cookie クリア", async () => {
+    mockAuth.mockResolvedValue(userSession());
+    const signed = await signedCookieFor("authreq_1");
+    mockPrisma.oIDCAuthRequest.findUnique.mockResolvedValue(validAuthRequest());
+
+    const { POST } = require("@/app/api/oidc/consent/route");
+    const res = await POST(
+      await makeRequest({ approve: true }, { signedHandle: signed }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const loc = new URL(body.redirectTo);
+    expect(loc.origin + loc.pathname).toBe(
+      "https://rp.example.lan/callback",
+    );
+    expect(loc.searchParams.get("code")).toMatch(/^code_/);
+    expect(loc.searchParams.get("state")).toBe("state_123");
+
+    expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=;/);
+
+    expect(mockPrisma.oIDCConsent.upsert).toHaveBeenCalled();
+    expect(mockPrisma.oIDCAuthCode.create).toHaveBeenCalled();
+    expect(mockPrisma.oIDCAuthRequest.delete).toHaveBeenCalled();
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_CONSENT_GRANT",
+        category: "OIDC",
+        details: expect.objectContaining({ auto: false }),
+      }),
+    );
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_AUTHORIZE",
+        category: "OIDC",
+      }),
+    );
+  });
+});

--- a/apps/web/__tests__/api/oidc/token.test.ts
+++ b/apps/web/__tests__/api/oidc/token.test.ts
@@ -1,0 +1,571 @@
+export {};
+
+/**
+ * OIDC Token エンドポイント契約テスト
+ *
+ * 検証対象:
+ * - Content-Type / grant_type / client_id / client_secret の検証
+ * - invalid_client / invalid_grant の各エラー条件
+ * - PKCE S256 検証（一致 / 不一致 / method違い）
+ * - 認可コード一回限り（reuse 検知 → accessToken revoke + 監査ログ）
+ * - redirect_uri / client_id の一致検証
+ * - 成功時のレスポンス形状 + OIDC_TOKEN_ISSUE 監査ログ
+ */
+
+// ============================================================
+// Mocks
+// ============================================================
+
+const mockAuditLog = jest.fn();
+jest.mock("@/lib/services/audit-service", () => ({
+  AuditService: { log: mockAuditLog },
+}));
+
+jest.mock("jose", () => ({
+  jwtVerify: jest.fn(),
+  SignJWT: class {
+    setProtectedHeader() { return this; }
+    setIssuer() { return this; }
+    setSubject() { return this; }
+    setAudience() { return this; }
+    setIssuedAt() { return this; }
+    setExpirationTime() { return this; }
+    setJti() { return this; }
+    sign() { return Promise.resolve("signed.jwt.token"); }
+  },
+}));
+
+const mockGetActiveSigningKey = jest.fn();
+jest.mock("@/lib/services/oidc/keys", () => ({
+  getActiveSigningKey: mockGetActiveSigningKey,
+  findKeyByKid: jest.fn(),
+  getPublicJwks: jest.fn(),
+}));
+
+const mockPrisma = {
+  oIDCClient: {
+    findUnique: jest.fn(),
+  },
+  oIDCAuthCode: {
+    findUnique: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  oIDCAccessToken: {
+    create: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  user: {
+    findUnique: jest.fn(),
+  },
+};
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+jest.mock("@/lib/services/rate-limiter", () => ({
+  checkRateLimit: jest.fn(() => ({ allowed: true, remaining: 100, resetMs: 60000 })),
+  getClientIp: jest.fn(() => "127.0.0.1"),
+}));
+
+beforeAll(() => {
+  process.env.OIDC_ISSUER = "http://localhost:3000";
+});
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const bcrypt = require("bcryptjs");
+const { createHash, randomBytes } = require("node:crypto");
+
+function makeFormRequest(
+  body: Record<string, string>,
+  options: { authHeader?: string; contentType?: string } = {},
+): Request {
+  const headers: Record<string, string> = {
+    "content-type": options.contentType ?? "application/x-www-form-urlencoded",
+  };
+  if (options.authHeader) headers.authorization = options.authHeader;
+  const form = new URLSearchParams(body).toString();
+  return new Request("http://localhost:3000/api/oidc/token", {
+    method: "POST",
+    headers,
+    body: form,
+  });
+}
+
+async function makeClient(
+  overrides: Partial<Record<string, unknown>> = {},
+): Promise<{ row: Record<string, unknown>; plainSecret: string }> {
+  const plainSecret = "test-secret-" + randomBytes(8).toString("hex");
+  const hash = await bcrypt.hash(plainSecret, 4); // テスト用に低コスト
+  const row = {
+    id: "client_row_1",
+    clientId: "client_public_abc",
+    clientSecretHash: hash,
+    name: "Test Client",
+    description: null,
+    redirectUris: ["https://rp.example.lan/callback"],
+    allowedScopes: ["openid", "profile", "email"],
+    allowedRoles: ["USER", "MANAGER", "EXECUTIVE", "ADMIN"],
+    enabled: true,
+    autoApprove: false,
+    createdBy: "admin_1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+  return { row, plainSecret };
+}
+
+function makeAuthCode(
+  verifier: string,
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return {
+    id: "code_xyz",
+    clientId: "client_row_1",
+    userId: "user_1",
+    redirectUri: "https://rp.example.lan/callback",
+    scope: "openid profile email",
+    nonce: "nonce_1",
+    codeChallenge: challenge,
+    codeChallengeMethod: "S256",
+    twoFactorUsed: true,
+    usedAt: null,
+    expiresAt: new Date(Date.now() + 60_000),
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function validUser() {
+  return {
+    id: "user_1",
+    email: "user@example.com",
+    emailVerified: new Date(),
+    name: "Test User",
+    image: null,
+    role: "USER",
+    twoFactorEnabled: false,
+    // その他不要フィールドは undefined で OK
+  };
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("Token エンドポイント契約", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetActiveSigningKey.mockResolvedValue({
+      kid: "k1",
+      privateKey: "stub-priv",
+      publicKey: "stub-pub",
+      publicJwk: {},
+    });
+  });
+
+  // ------------------ request 形式 ------------------
+
+  it("Content-Type が form でない場合 invalid_request", async () => {
+    const { POST } = require("@/app/api/oidc/token/route");
+    const req = makeFormRequest({}, { contentType: "application/json" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("grant_type != authorization_code で unsupported_grant_type", async () => {
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "client_credentials",
+        client_id: "c",
+        client_secret: "s",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("unsupported_grant_type");
+  });
+
+  // ------------------ client 認証 ------------------
+
+  it("client_id/client_secret 欠如で 401 invalid_client", async () => {
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({ grant_type: "authorization_code" }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("誤った client_secret で 401 invalid_client", async () => {
+    const { row } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: "wrong",
+        code: "x",
+        redirect_uri: "x",
+        code_verifier: "x",
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("クライアント enabled=false で invalid_client", async () => {
+    const { row, plainSecret } = await makeClient({ enabled: false });
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "x",
+        redirect_uri: "x",
+        code_verifier: "x",
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("HTTP Basic での client 認証も受け付ける", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(null); // その後 invalid_grant で止まる
+
+    const basic = Buffer.from(`${row.clientId}:${plainSecret}`).toString(
+      "base64",
+    );
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest(
+        {
+          grant_type: "authorization_code",
+          code: "x",
+          redirect_uri: "x",
+          code_verifier: "x",
+        },
+        { authHeader: `Basic ${basic}` },
+      ),
+    );
+    // client 認証を通り、authCode 検証で invalid_grant になる
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  // ------------------ 必須パラメータ ------------------
+
+  it("code / redirect_uri / code_verifier 欠如で invalid_request", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_request");
+  });
+
+  // ------------------ authCode 検証 ------------------
+
+  it("不明な code で invalid_grant (not_found)", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(null);
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "missing",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: "v",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toMatch(/not_found/);
+  });
+
+  it("期限切れ code で invalid_grant (expired)", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(
+      makeAuthCode(verifier, { expiresAt: new Date(Date.now() - 1000) }),
+    );
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/expired/);
+  });
+
+  it("使用済み code (reuse) で invalid_grant + accessToken revoke + 監査ログ", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(
+      makeAuthCode(verifier, { usedAt: new Date() }),
+    );
+    mockPrisma.oIDCAccessToken.updateMany.mockResolvedValue({ count: 3 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toMatch(/reuse/);
+
+    // revoke が呼ばれている
+    expect(mockPrisma.oIDCAccessToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clientId: "client_row_1",
+          userId: "user_1",
+          revokedAt: null,
+        }),
+        data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+      }),
+    );
+
+    // 監査ログ記録
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_TOKEN_REUSE_DETECTED",
+        category: "OIDC",
+      }),
+    );
+  });
+
+  it("競合で updateMany.count=0 の場合も reuse 扱い", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(makeAuthCode(verifier));
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.oIDCAccessToken.updateMany.mockResolvedValue({ count: 0 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("redirect_uri 不一致で invalid_grant", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(makeAuthCode(verifier));
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://different.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/redirect_uri/);
+  });
+
+  it("他クライアントの code で invalid_grant", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(
+      makeAuthCode(verifier, { clientId: "other_client_row" }),
+    );
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/not issued to this client/);
+  });
+
+  it("codeChallengeMethod != S256 で invalid_grant", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(
+      makeAuthCode(verifier, { codeChallengeMethod: "plain" }),
+    );
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/code_challenge_method/);
+  });
+
+  it("PKCE verifier 不一致で invalid_grant", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(makeAuthCode(verifier));
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: "wrong_verifier",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/code_verifier/);
+  });
+
+  // ------------------ 成功系 ------------------
+
+  it("成功: access_token/id_token 返却 + OIDC_TOKEN_ISSUE 監査ログ", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(makeAuthCode(verifier));
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.user.findUnique.mockResolvedValue(validUser());
+    mockPrisma.oIDCAccessToken.create.mockResolvedValue({ id: "jti_1" });
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.token_type).toBe("Bearer");
+    expect(body.access_token).toBeTruthy();
+    expect(body.id_token).toBeTruthy();
+    expect(body.scope).toBe("openid profile email");
+    expect(body.expires_in).toBeGreaterThan(0);
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_TOKEN_ISSUE",
+        category: "OIDC",
+        userId: "user_1",
+      }),
+    );
+    // accessToken が DB に記録された
+    expect(mockPrisma.oIDCAccessToken.create).toHaveBeenCalled();
+  });
+
+  it("成功パスで user が見つからない場合 invalid_grant", async () => {
+    const { row, plainSecret } = await makeClient();
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(row);
+    const verifier = "v".repeat(64);
+    mockPrisma.oIDCAuthCode.findUnique.mockResolvedValue(makeAuthCode(verifier));
+    mockPrisma.oIDCAuthCode.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const { POST } = require("@/app/api/oidc/token/route");
+    const res = await POST(
+      makeFormRequest({
+        grant_type: "authorization_code",
+        client_id: row.clientId as string,
+        client_secret: plainSecret,
+        code: "code_xyz",
+        redirect_uri: "https://rp.example.lan/callback",
+        code_verifier: verifier,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_description).toMatch(/user not found/);
+  });
+});

--- a/apps/web/__tests__/api/oidc/userinfo.test.ts
+++ b/apps/web/__tests__/api/oidc/userinfo.test.ts
@@ -1,0 +1,325 @@
+export {};
+
+/**
+ * OIDC UserInfo エンドポイント契約テスト
+ *
+ * 検証対象:
+ * - Bearer 未指定 / 空 Bearer → 401 invalid_token + WWW-Authenticate
+ * - 署名検証失敗 → 401 invalid_token
+ * - DB 側で revoke / expired → 401 invalid_token
+ * - user not found → 401 invalid_token
+ * - 成功時: scope 別クレーム返却 + OIDC_USERINFO_ACCESS 監査ログ
+ */
+
+// ============================================================
+// Mocks
+// ============================================================
+
+const mockAuditLog = jest.fn();
+jest.mock("@/lib/services/audit-service", () => ({
+  AuditService: { log: mockAuditLog },
+}));
+
+// jose は ESM-only のため Jest から直接 import 不可
+const mockJwtVerify = jest.fn();
+jest.mock("jose", () => ({
+  jwtVerify: mockJwtVerify,
+  SignJWT: class {
+    setProtectedHeader() { return this; }
+    setIssuer() { return this; }
+    setSubject() { return this; }
+    setAudience() { return this; }
+    setIssuedAt() { return this; }
+    setExpirationTime() { return this; }
+    setJti() { return this; }
+    sign() { return Promise.resolve("stub.jwt.token"); }
+  },
+}));
+
+const mockFindKeyByKid = jest.fn();
+jest.mock("@/lib/services/oidc/keys", () => ({
+  findKeyByKid: mockFindKeyByKid,
+  getActiveSigningKey: jest.fn(),
+  getPublicJwks: jest.fn(),
+}));
+
+const mockPrisma = {
+  oIDCAccessToken: {
+    findUnique: jest.fn(),
+  },
+  user: {
+    findUnique: jest.fn(),
+  },
+};
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// rate limiter は常に allow（契約テストでは429を発火させない）
+jest.mock("@/lib/services/rate-limiter", () => ({
+  checkRateLimit: jest.fn(() => ({ allowed: true, remaining: 100, resetMs: 60000 })),
+  getClientIp: jest.fn(() => "127.0.0.1"),
+}));
+
+// OIDC_ISSUER を環境変数に
+beforeAll(() => {
+  process.env.OIDC_ISSUER = "http://localhost:3000";
+});
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function makeRequest(
+  authHeader?: string,
+  method: "GET" | "POST" = "GET",
+): Request {
+  const headers: Record<string, string> = {};
+  if (authHeader !== undefined) headers.authorization = authHeader;
+  return new Request("http://localhost:3000/api/oidc/userinfo", {
+    method,
+    headers,
+  });
+}
+
+function validDbRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "jti_1",
+    clientId: "client_row_1",
+    userId: "user_1",
+    scope: "openid profile email",
+    tokenHash: "hash",
+    expiresAt: new Date(Date.now() + 60_000),
+    revokedAt: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function validUser(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "user_1",
+    email: "user@example.com",
+    emailVerified: new Date(),
+    name: "Test User",
+    image: "https://example.com/a.png",
+    role: "MANAGER",
+    language: "ja",
+    timezone: "Asia/Tokyo",
+    braveApiKey: null,
+    systemPrompt: null,
+    orgContextEnabled: true,
+    lastSignInAt: null,
+    twoFactorEnabled: false,
+    twoFactorSecret: null,
+    forcePasswordChange: false,
+    passwordExpiresAt: null,
+    password: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// base64url でヘッダー { kid: "k1" } を作って JWT 風の文字列にする
+function makeFakeJwt(kid = "k1"): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid }))
+    .toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub: "user_1" }))
+    .toString("base64url");
+  return `${header}.${payload}.fakesignature`;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("UserInfo エンドポイント契約", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Authorization ヘッダなしで 401 invalid_token", async () => {
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toMatch(/Bearer error="invalid_token"/);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_token");
+  });
+
+  it("Bearer が空文字のみで 401 invalid_token", async () => {
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest("Bearer "));
+    expect(res.status).toBe(401);
+  });
+
+  it("Bearer 以外のスキーマ（Basic等）で 401", async () => {
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest("Basic abc"));
+    expect(res.status).toBe(401);
+  });
+
+  it("kid 欠如の JWT で 401 invalid_token", async () => {
+    // kid の無いトークン
+    const headerNoKid = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+      "base64url",
+    );
+    const payload = Buffer.from(JSON.stringify({ sub: "x" })).toString(
+      "base64url",
+    );
+    const token = `${headerNoKid}.${payload}.sig`;
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${token}`));
+    expect(res.status).toBe(401);
+    expect(mockFindKeyByKid).not.toHaveBeenCalled();
+  });
+
+  it("kid に対応する鍵が見つからない場合 401", async () => {
+    mockFindKeyByKid.mockResolvedValue(null);
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt("unknown_kid")}`));
+
+    expect(res.status).toBe(401);
+    expect(mockFindKeyByKid).toHaveBeenCalledWith("unknown_kid");
+  });
+
+  it("署名検証エラーで 401", async () => {
+    mockFindKeyByKid.mockResolvedValue({
+      kid: "k1",
+      publicKey: "stub-public-key",
+    });
+    mockJwtVerify.mockRejectedValue(new Error("signature verification failed"));
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("DB に行がない場合 401（revoke 後や DB 削除後）", async () => {
+    mockFindKeyByKid.mockResolvedValue({
+      kid: "k1",
+      publicKey: "stub-public-key",
+    });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid profile" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(null);
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("DB 行が revokedAt != null で 401", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid profile" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(
+      validDbRow({ revokedAt: new Date() }),
+    );
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("DB 行が expiresAt < 現在で 401", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid profile" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(
+      validDbRow({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("user not found で 401", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid profile" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(validDbRow());
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("成功時: sub/email/profile クレーム返却 + 監査ログ記録", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: {
+        sub: "user_1",
+        aud: "client_abc",
+        scope: "openid profile email",
+      },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(validDbRow());
+    mockPrisma.user.findUnique.mockResolvedValue(validUser());
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sub).toBe("user_1");
+    expect(body.email).toBe("user@example.com");
+    expect(body.email_verified).toBe(true);
+    expect(body.name).toBe("Test User");
+    expect(body["lion:role"]).toBe("MANAGER");
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_USERINFO_ACCESS",
+        category: "OIDC",
+        userId: "user_1",
+      }),
+    );
+  });
+
+  it("scope が openid のみの場合、email/profile クレームは含まれない", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(
+      validDbRow({ scope: "openid" }),
+    );
+    mockPrisma.user.findUnique.mockResolvedValue(validUser());
+
+    const { GET } = require("@/app/api/oidc/userinfo/route");
+    const res = await GET(makeRequest(`Bearer ${makeFakeJwt()}`));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sub).toBe("user_1");
+    expect(body.email).toBeUndefined();
+    expect(body.name).toBeUndefined();
+    expect(body["lion:role"]).toBeUndefined();
+  });
+
+  it("POST でも GET と同じ契約で動作する", async () => {
+    mockFindKeyByKid.mockResolvedValue({ kid: "k1", publicKey: "pk" });
+    mockJwtVerify.mockResolvedValue({
+      payload: { sub: "user_1", aud: "client_1", scope: "openid profile" },
+    });
+    mockPrisma.oIDCAccessToken.findUnique.mockResolvedValue(validDbRow());
+    mockPrisma.user.findUnique.mockResolvedValue(validUser());
+
+    const { POST } = require("@/app/api/oidc/userinfo/route");
+    const res = await POST(makeRequest(`Bearer ${makeFakeJwt()}`, "POST"));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

PR #7 のレビューで判明した Critical バグ（`verifyAccessToken` が秘密鍵で検証）は、単体テストのみでは検出できなかった。各 OIDC endpoint の動作契約を固めるため、**レベル1（モックベース契約テスト）**を追加する。

## 追加テスト（4 suites / 52 tests）

| ファイル | テスト数 | 主なカバー範囲 |
|---|---|---|
| `authorize.test.ts` | 16 | パラメータ検証 / 未ログインリダイレクト / allowedRoles / autoApprove / 既存同意包含 / rate limit |
| `token.test.ts` | 17 | client 認証（Basic/form）/ invalid_grant 各種 / **reuse 検知＋revoke＋AUDIT** / PKCE 検証 / 成功応答 |
| `userinfo.test.ts` | 13 | Bearer 検証 / kid 解決 / 署名検証 / DB revoke・expire / scope 別クレーム / 監査ログ |
| `consent.test.ts` | 6 | 未ログイン / handle 欠如 / 期限切れ / approve=false / allowedRoles 後変更 / 成功時の code 発行 |

## 特に検証強化した観点

### セキュリティ契約

- [x] 認可コードの再利用検知 → 関連 accessToken revoke
- [x] PKCE S256 verifier 不一致で invalid_grant
- [x] redirect_uri 一致のみ許可（発行時との完全一致）
- [x] 他クライアントの code は受け付けない
- [x] 無効化されたクライアントは認可拒否

### 監査ログ契約

以下の action が意図通り記録されることを assertion で検証:
- `OIDC_TOKEN_ISSUE` / `OIDC_TOKEN_REUSE_DETECTED`
- `OIDC_AUTHORIZE` / `OIDC_AUTHORIZE_DENIED`
- `OIDC_CONSENT_GRANT`（`auto: true/false` フラグ込み）
- `OIDC_USERINFO_ACCESS`

### モック方針

- **Prisma / @/auth / audit-service / rate-limiter**: モック
- **jose**: ESM-only のため `SignJWT` / `jwtVerify` をスタブ化
- **bcryptjs / cookie-signer / token-service の pure ロジック**: 実物を使用（verifyPkceS256 や signValue を含む）

これにより、ルートハンドラの「外部依存の境界」を固定しつつ、内部ロジックは実コードで動作することを確認している。

## 結果

- ✅ 追加テスト 52 件全 PASS
- ✅ OIDC 全体（単体 15 + API 契約 52）= **67 件 PASS**
- ✅ 既存テストへの regression なし（既存の GUEST ロール由来の 2 件失敗は本 PR 無関係）
- ✅ TypeScript 型チェックパス

## 今後のテスト戦略

- **レベル 2（実 DB 統合テスト）**: 今後 Critical 再発時の最終防衛線として検討余地あり
- **レベル 3（Playwright E2E）**: 運用負荷対費用で要検討

本 PR でレベル 1 の保護は整ったため、派生プロジェクトでの動作確認（手動 E2E）に進める状態となった。

## Test plan

- [ ] `pnpm test -- __tests__/api/oidc __tests__/lib/services/oidc` で全 67 件 PASS 確認
- [ ] 型チェック `npx tsc --noEmit` で新規テストファイル由来のエラーなし
- [ ] 既存テスト全体 `pnpm test` で regression なし（GUEST ロール由来の 2 件失敗は既知）

🤖 Generated with [Claude Code](https://claude.com/claude-code)