### PR TITLE
ci(claude-review): ドキュメントのみの PR では自動レビューをスキップ

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+    # ドキュメントのみの PR では Claude API の従量課金を避けるため自動レビューをスキップ。
+    # コード変更と同時に docs を変更する PR ではコード側がマッチするため通常どおりレビューされる。
+    # ドキュメント単独でレビューが欲しい場合は手動で @claude とコメント（issue_comment トリガ）。
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'LICENSE'
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Summary

Anthropic API の従量課金を節約するため、\`.github/workflows/claude-review.yml\` に \`paths-ignore\` を追加し、ドキュメントのみの PR では Claude Code Review を自動実行しないようにする。

## 変更内容

\`\`\`yaml
on:
  pull_request:
    types: [opened, synchronize, ready_for_review]
    paths-ignore:
      - '**.md'
      - 'docs/**'
      - '.claude/**'
      - 'LICENSE'
  issue_comment:
    types: [created]
\`\`\`

## 挙動

| PR の内容 | レビュー実行 |
|-----------|:---:|
| コード（\`.ts\`/\`.tsx\` 等）のみ | ✅ 実行 |
| コード + docs 混在 | ✅ 実行（paths-ignore は全変更ファイルがマッチする場合のみ有効） |
| \`.md\` / \`docs/\` / \`.claude/\` のみ | ❌ スキップ |

## フォールバック

ドキュメント単独でも AI レビューが欲しいときは PR コメントで \`@claude\` とメンションすれば、\`issue_comment\` トリガで手動レビュー起動できる。

## 温存

- \`issue_comment\` トリガ（\`@claude\` メンション）は変更なし
- \`if\` 条件（draft スキップ・@claude 条件）も変更なし
- GitHub Actions 自体の無料枠は従量課金の対象外（Anthropic API コストのみ節約）

## Test plan

- [ ] マージ後、docs 変更のみの次回 PR でレビューがスキップされるか確認
- [ ] コード変更を含む PR では従来どおりレビューが走るか確認
- [ ] PR コメントで \`@claude\` メンションすると手動起動できるか確認

## 補足

PR #15（ドキュメント整合性）の自動レビューを進行中にキャンセル済み（run id: 24624469422）。PR #15 マージ後はこの設定により同様の PR で API コストが発生しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)