### PR TITLE
refactor(webauthn): UI/API パターンを本家の標準に統一 (#19)

### DIFF
--- a/apps/web/app/(main)/settings/PasskeySection.tsx
+++ b/apps/web/app/(main)/settings/PasskeySection.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
 import { Input } from "@/components/ui/input";
 
 type Credential = {
@@ -31,6 +32,7 @@ type PasskeyTranslations = {
   saveNickname: string;
   cancel: string;
   delete: string;
+  deleteTitle: string;
   confirmDelete: string;
   lastUsedAt: string;
   createdAt: string;
@@ -70,6 +72,10 @@ export function PasskeySection({
   const [nickname, setNickname] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingNickname, setEditingNickname] = useState("");
+  const [targetCredential, setTargetCredential] = useState<Credential | null>(
+    null,
+  );
+  const [deleting, setDeleting] = useState(false);
   const [message, setMessage] = useState<{
     type: "success" | "error";
     text: string;
@@ -137,31 +143,34 @@ export function PasskeySection({
     }
   }, [nickname, t, loadCredentials]);
 
-  const handleDelete = useCallback(
-    async (credential: Credential) => {
-      if (!confirm(t.confirmDelete)) return;
-      setBusy(true);
-      setMessage(null);
-      try {
-        const res = await fetch(
-          `/api/user/webauthn/credentials/${credential.id}`,
-          { method: "DELETE" },
-        );
-        if (res.status === 409) {
-          setMessage({ type: "error", text: t.lastPasskeyBlocked });
-          return;
-        }
-        if (!res.ok) throw new Error("delete");
-        setMessage({ type: "success", text: t.deleteSuccess });
-        await loadCredentials();
-      } catch (_error) {
-        setMessage({ type: "error", text: t.error });
-      } finally {
-        setBusy(false);
+  const requestDelete = useCallback((credential: Credential) => {
+    setTargetCredential(credential);
+    setMessage(null);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!targetCredential) return;
+    setDeleting(true);
+    setMessage(null);
+    try {
+      const res = await fetch(
+        `/api/user/webauthn/credentials/${targetCredential.id}`,
+        { method: "DELETE" },
+      );
+      if (res.status === 409) {
+        setMessage({ type: "error", text: t.lastPasskeyBlocked });
+        return;
       }
-    },
-    [t, loadCredentials],
-  );
+      if (!res.ok) throw new Error("delete");
+      setMessage({ type: "success", text: t.deleteSuccess });
+      await loadCredentials();
+    } catch (_error) {
+      setMessage({ type: "error", text: t.error });
+    } finally {
+      setDeleting(false);
+      setTargetCredential(null);
+    }
+  }, [targetCredential, t, loadCredentials]);
 
   const startEditNickname = useCallback((credential: Credential) => {
     setEditingId(credential.id);
@@ -362,7 +371,7 @@ export function PasskeySection({
                     <Button
                       size="sm"
                       variant="danger"
-                      onClick={() => handleDelete(c)}
+                      onClick={() => requestDelete(c)}
                       disabled={busy}
                     >
                       {t.delete}
@@ -374,6 +383,19 @@ export function PasskeySection({
           ))}
         </ul>
       )}
+
+      <DeleteConfirmDialog
+        open={targetCredential !== null}
+        onOpenChange={(open) => {
+          if (!open) setTargetCredential(null);
+        }}
+        title={t.deleteTitle}
+        description={t.confirmDelete}
+        cancelLabel={t.cancel}
+        deleteLabel={t.delete}
+        disabled={deleting}
+        onDelete={confirmDelete}
+      />
     </div>
   );
 }

--- a/apps/web/app/(main)/settings/translations.ts
+++ b/apps/web/app/(main)/settings/translations.ts
@@ -105,6 +105,7 @@ export const settingsTranslations = {
       saveNickname: "Save",
       cancel: "Cancel",
       delete: "Delete",
+      deleteTitle: "Delete passkey",
       confirmDelete:
         "Are you sure you want to delete this passkey? You will no longer be able to sign in with it.",
       lastUsedAt: "Last used",
@@ -234,6 +235,7 @@ export const settingsTranslations = {
       saveNickname: "保存",
       cancel: "キャンセル",
       delete: "削除",
+      deleteTitle: "パスキーを削除",
       confirmDelete:
         "このパスキーを削除してよろしいですか？ このパスキーではサインインできなくなります。",
       lastUsedAt: "最終使用日時",

--- a/apps/web/app/api/user/webauthn/credentials/[id]/route.ts
+++ b/apps/web/app/api/user/webauthn/credentials/[id]/route.ts
@@ -4,85 +4,85 @@ import { CredentialService } from "@/lib/webauthn/credential-service";
 
 const NICKNAME_MAX = 64;
 
-async function resolveId(request: Request): Promise<string> {
-  const url = new URL(request.url);
-  const segments = url.pathname.split("/").filter(Boolean);
-  return segments[segments.length - 1] ?? "";
-}
+type RouteContext = { params: Promise<{ id: string }> };
 
-export const PATCH = apiHandler(async (request, session) => {
-  const id = await resolveId(request);
-  if (!id) throw ApiError.badRequest("missing credential id");
+export const PATCH = apiHandler<{ success: true }, RouteContext>(
+  async (request, session, { params }) => {
+    const { id } = await params;
+    if (!id) throw ApiError.badRequest("missing credential id");
 
-  const body = (await request.json().catch(() => null)) as {
-    nickname?: string | null;
-  } | null;
+    const body = (await request.json().catch(() => null)) as {
+      nickname?: string | null;
+    } | null;
 
-  if (!body || !("nickname" in body)) {
-    throw ApiError.badRequest("nickname is required");
-  }
-
-  let nickname: string | null = null;
-  if (typeof body.nickname === "string") {
-    const trimmed = body.nickname.trim();
-    if (trimmed.length === 0) {
-      nickname = null;
-    } else if (trimmed.length > NICKNAME_MAX) {
-      throw ApiError.badRequest(
-        `nickname must be ${NICKNAME_MAX} characters or less`,
-      );
-    } else {
-      nickname = trimmed;
+    if (!body || !("nickname" in body)) {
+      throw ApiError.badRequest("nickname is required");
     }
-  }
 
-  const updated = await CredentialService.updateNickname(
-    id,
-    session.user.id,
-    nickname,
-  );
+    let nickname: string | null = null;
+    if (typeof body.nickname === "string") {
+      const trimmed = body.nickname.trim();
+      if (trimmed.length === 0) {
+        nickname = null;
+      } else if (trimmed.length > NICKNAME_MAX) {
+        throw ApiError.badRequest(
+          `nickname must be ${NICKNAME_MAX} characters or less`,
+        );
+      } else {
+        nickname = trimmed;
+      }
+    }
 
-  if (!updated) {
-    throw ApiError.notFound("credential not found");
-  }
-
-  await AuditService.log({
-    action: "WEBAUTHN_NICKNAME_UPDATE",
-    category: "USER_MANAGEMENT",
-    userId: session.user.id,
-    targetId: id,
-    targetType: "WebAuthnCredential",
-  });
-
-  return { success: true };
-});
-
-export const DELETE = apiHandler(async (request, session) => {
-  const id = await resolveId(request);
-  if (!id) throw ApiError.badRequest("missing credential id");
-
-  const canRemove = await CredentialService.canUserRemoveCredential(
-    session.user.id,
-  );
-  if (!canRemove) {
-    throw ApiError.conflict(
-      "Cannot remove the last passkey when no password is set",
-      "パスワードが設定されていないため、最後のパスキーは削除できません",
+    const updated = await CredentialService.updateNickname(
+      id,
+      session.user.id,
+      nickname,
     );
-  }
 
-  const deleted = await CredentialService.delete(id, session.user.id);
-  if (!deleted) {
-    throw ApiError.notFound("credential not found");
-  }
+    if (!updated) {
+      throw ApiError.notFound("credential not found");
+    }
 
-  await AuditService.log({
-    action: "WEBAUTHN_DELETE",
-    category: "USER_MANAGEMENT",
-    userId: session.user.id,
-    targetId: id,
-    targetType: "WebAuthnCredential",
-  });
+    await AuditService.log({
+      action: "WEBAUTHN_NICKNAME_UPDATE",
+      category: "USER_MANAGEMENT",
+      userId: session.user.id,
+      targetId: id,
+      targetType: "WebAuthnCredential",
+    });
 
-  return { success: true };
-});
+    return { success: true };
+  },
+);
+
+export const DELETE = apiHandler<{ success: true }, RouteContext>(
+  async (_request, session, { params }) => {
+    const { id } = await params;
+    if (!id) throw ApiError.badRequest("missing credential id");
+
+    const canRemove = await CredentialService.canUserRemoveCredential(
+      session.user.id,
+    );
+    if (!canRemove) {
+      throw ApiError.conflict(
+        "Cannot remove the last passkey when no password is set",
+        "パスワードが設定されていないため、最後のパスキーは削除できません",
+      );
+    }
+
+    const deleted = await CredentialService.delete(id, session.user.id);
+    if (!deleted) {
+      throw ApiError.notFound("credential not found");
+    }
+
+    await AuditService.log({
+      action: "WEBAUTHN_DELETE",
+      category: "USER_MANAGEMENT",
+      userId: session.user.id,
+      targetId: id,
+      targetType: "WebAuthnCredential",
+    });
+
+    return { success: true };
+  },
+);

--- a/apps/web/components/admin/UserPasskeyDialog.tsx
+++ b/apps/web/components/admin/UserPasskeyDialog.tsx
@@ -2,8 +2,10 @@
 
 import { Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
 import {
   Dialog,
   DialogContent,
@@ -43,6 +45,9 @@ export function UserPasskeyDialog({
   const [credentials, setCredentials] = useState<Credential[]>([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
+  const [targetCredential, setTargetCredential] = useState<Credential | null>(
+    null,
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -62,41 +67,40 @@ export function UserPasskeyDialog({
     if (open) load();
   }, [open, load]);
 
-  const handleDelete = useCallback(
-    async (credential: Credential) => {
-      const msg = t(
-        `Are you sure you want to force-delete this passkey? The user will no longer be able to sign in with it.`,
-        "このパスキーを強制削除してよろしいですか？ ユーザはこのパスキーでサインインできなくなります。",
+  const requestDelete = useCallback((credential: Credential) => {
+    setTargetCredential(credential);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!targetCredential) return;
+    const credential = targetCredential;
+    setBusy(credential.id);
+    try {
+      const res = await fetch(
+        `/api/admin/users/${userId}/webauthn/${credential.id}`,
+        { method: "DELETE" },
       );
-      if (!confirm(msg)) return;
-      setBusy(credential.id);
-      try {
-        const res = await fetch(
-          `/api/admin/users/${userId}/webauthn/${credential.id}`,
-          { method: "DELETE" },
-        );
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          throw new Error(data.errorJa ?? data.error ?? "delete failed");
-        }
-        await load();
-      } catch (error) {
-        alert(
-          t(
-            error instanceof Error
-              ? error.message
-              : "Failed to delete passkey",
-            error instanceof Error
-              ? error.message
-              : "パスキーの削除に失敗しました",
-          ),
-        );
-      } finally {
-        setBusy(null);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.errorJa ?? data.error ?? "delete failed");
       }
-    },
-    [userId, load, t],
-  );
+      await load();
+    } catch (error) {
+      toast.error(
+        t(
+          error instanceof Error
+            ? error.message
+            : "Failed to delete passkey",
+          error instanceof Error
+            ? error.message
+            : "パスキーの削除に失敗しました",
+        ),
+      );
+    } finally {
+      setBusy(null);
+      setTargetCredential(null);
+    }
+  }, [targetCredential, userId, load, t]);
 
   const formatDate = useCallback(
     (iso: string | null) => {
@@ -164,7 +168,7 @@ export function UserPasskeyDialog({
                 <Button
                   variant="destructive"
                   size="sm"
-                  onClick={() => handleDelete(c)}
+                  onClick={() => requestDelete(c)}
                   disabled={busy === c.id}
                   loading={busy === c.id}
                 >
@@ -181,6 +185,21 @@ export function UserPasskeyDialog({
           </Button>
         </DialogFooter>
       </DialogContent>
+      <DeleteConfirmDialog
+        open={targetCredential !== null}
+        onOpenChange={(next) => {
+          if (!next) setTargetCredential(null);
+        }}
+        title={t("Delete passkey", "パスキーを削除")}
+        description={t(
+          "Are you sure you want to force-delete this passkey? The user will no longer be able to sign in with it.",
+          "このパスキーを強制削除してよろしいですか？ ユーザはこのパスキーでサインインできなくなります。",
+        )}
+        cancelLabel={t("Cancel", "キャンセル")}
+        deleteLabel={t("Delete", "削除")}
+        disabled={busy !== null}
+        onDelete={confirmDelete}
+      />
     </Dialog>
   );
 }

--- a/apps/web/lib/api/api-handler.ts
+++ b/apps/web/lib/api/api-handler.ts
@@ -9,9 +9,10 @@ import {
   requireRole,
 } from "./auth-guard";
 
-type HandlerFn<T = unknown> = (
+type HandlerFn<T = unknown, Ctx = unknown> = (
   request: Request,
   session: Session,
+  context: Ctx,
 ) => Promise<T>;
 
 interface ApiHandlerOptions {
@@ -37,18 +38,22 @@ interface ApiHandlerOptions {
  *   return { items };
  * }, { admin: true });
  *
- * export const POST = apiHandler(async (req, session) => {
- *   const body = await req.json();
- *   const item = await prisma.item.create({ data: body });
- *   return { item };
- * }, { admin: true, successStatus: 201 });
+ * // Dynamic routes can receive Next.js route context as the third argument.
+ * export const DELETE = apiHandler<
+ *   { success: true },
+ *   { params: Promise<{ id: string }> }
+ * >(async (req, session, { params }) => {
+ *   const { id } = await params;
+ *   await prisma.item.delete({ where: { id } });
+ *   return { success: true };
+ * });
  * ```
  */
-export function apiHandler<T>(
-  handler: HandlerFn<T>,
+export function apiHandler<T, Ctx = unknown>(
+  handler: HandlerFn<T, Ctx>,
   options: ApiHandlerOptions = {},
-): (request: Request) => Promise<NextResponse> {
-  return async (request: Request) => {
+): (request: Request, context?: Ctx) => Promise<NextResponse> {
+  return async (request: Request, context?: Ctx) => {
     try {
       let session: Session;
 
@@ -66,7 +71,7 @@ export function apiHandler<T>(
         session = await requireAuth();
       }
 
-      const result = await handler(request, session);
+      const result = await handler(request, session, context as Ctx);
       return NextResponse.json(result, {
         status: options.successStatus ?? 200,
       });


### PR DESCRIPTION
## Summary

Issue #19 で指摘された WebAuthn/Passkey 周りの UI/API パターン不統一 3 件を、本家の標準に揃えます。

- **手動 URL パース → params パターン**: `/api/user/webauthn/credentials/[id]/route.ts` の `resolveId(request)` を削除し、Next.js の `{ params }` Promise を受け取る形に変更。
- **`apiHandler` の拡張**: ハンドラが Next.js route context を透過で受け取れるよう、オプショナル第 3 引数 `context` を追加。既存 144 ファイルは `context` を参照しないため無変更で動作（後方互換）。
- **`window.confirm()` → `DeleteConfirmDialog`**: `settings/PasskeySection` と `admin/UserPasskeyDialog` を他メニューと同じ削除ダイアログ UX に統一。
- **`window.alert()` → `toast.error()`**: `admin/UserPasskeyDialog` のエラー表示を sonner の toast に統一（`OidcClientsClient` など他 admin 画面と同じパターン）。

Closes #19

## Test plan

- [x] TypeScript 型チェック (`tsc --noEmit`) がエラーなし
- [x] Biome lint（変更 5 ファイル）がエラーなし
- [x] Jest テスト（webauthn / password / change-password 関連）46 件全 pass
- [ ] `/settings` でパスキー登録 → 削除ボタン → `DeleteConfirmDialog` → 削除成功トースト
- [ ] `/settings` でニックネーム変更（PATCH）が引き続き動作
- [ ] admin ログインで `/admin` → ユーザ管理 → パスキーダイアログ → 強制削除（確認ダイアログ → 成功時はリスト更新、失敗時は toast.error）
- [ ] パスワード未設定状態で最後のパスキーを削除 → `lastPasskeyBlocked` の Alert 表示（409 ハンドリング）

🤖 Generated with [Claude Code](https://claude.com/claude-code)