### PR TITLE
feat(docker): Next.js 開発用コンテナを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/node_modules
+**/.next
+**/.turbo
+**/dist
+**/coverage
+**/.DS_Store
+.git
+.gitignore
+.vscode
+.idea
+*.log
+backend/chroma_data
+backend/model_cache
+backend/__pycache__
+backend/venv

--- a/apps/web/Dockerfile.dev
+++ b/apps/web/Dockerfile.dev
@@ -8,6 +8,8 @@ RUN corepack enable && corepack prepare pnpm@10.6.5 --activate
 
 WORKDIR /app
 
+# NOTE: 新しいワークスペース（addons/*, mcp-servers/*, packages/*）を追加する際は
+# 下記の COPY 行を手動で追加すること。pnpm-workspace.yaml のパターンとの整合に注意。
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/
 COPY packages/module-types/package.json packages/module-types/
@@ -16,9 +18,7 @@ COPY mcp-servers/organization/package.json mcp-servers/organization/
 
 RUN pnpm install --frozen-lockfile
 
-COPY apps/web/prisma apps/web/prisma
-RUN cd apps/web && pnpm exec prisma generate
-
 EXPOSE 3030
 
+# prisma generate は起動時に実行（schema は bind mount されるため）
 CMD ["sh", "-c", "cd apps/web && pnpm exec prisma generate && pnpm exec next dev -H 0.0.0.0 -p 3030"]

--- a/apps/web/Dockerfile.dev
+++ b/apps/web/Dockerfile.dev
@@ -1,0 +1,24 @@
+FROM node:20-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openssl ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@10.6.5 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/
+COPY packages/module-types/package.json packages/module-types/
+COPY addons/ai-playground/package.json addons/ai-playground/
+COPY mcp-servers/organization/package.json mcp-servers/organization/
+
+RUN pnpm install --frozen-lockfile
+
+COPY apps/web/prisma apps/web/prisma
+RUN cd apps/web && pnpm exec prisma generate
+
+EXPOSE 3030
+
+CMD ["sh", "-c", "cd apps/web && pnpm exec prisma generate && pnpm exec next dev -H 0.0.0.0 -p 3030"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      airag-backend:
-        condition: service_started
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://lionframe:lionframe@postgres:5432/lionframe?schema=public
       AUTH_URL: http://localhost:3030
+      # 開発環境専用のフォールバック。本番・ステージングでは必ず強力なランダム文字列を設定すること
+      # 生成例: openssl rand -base64 32
       AUTH_SECRET: ${AUTH_SECRET:-dev-secret-change-me}
       OIDC_ISSUER: http://localhost:3030
       OIDC_SIGNING_KEYS: ${OIDC_SIGNING_KEYS:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,48 @@ services:
       timeout: 5s
       retries: 5
 
+  # Next.js Web App (開発コンテナ)
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile.dev
+    container_name: lionframe-web
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      airag-backend:
+        condition: service_started
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://lionframe:lionframe@postgres:5432/lionframe?schema=public
+      AUTH_URL: http://localhost:3030
+      AUTH_SECRET: ${AUTH_SECRET:-dev-secret-change-me}
+      OIDC_ISSUER: http://localhost:3030
+      OIDC_SIGNING_KEYS: ${OIDC_SIGNING_KEYS:-}
+      RAG_BACKEND_URL: http://airag-backend:8000
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:8080}
+      NEXT_PUBLIC_APP_NAME: LionFrame
+      NEXT_PUBLIC_APP_DESCRIPTION: Modular framework for back-office operations
+      NEXT_PUBLIC_APP_DESCRIPTION_JA: バックオフィス業務を支援するモジュラーフレームワーク
+      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
+      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
+      NEXT_PUBLIC_WEBAUTHN_RP_ID: localhost
+      NEXT_PUBLIC_WEBAUTHN_RP_NAME: LionFrame
+      WEBAUTHN_ORIGIN: http://localhost:3030
+      WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
+    ports:
+      - "3030:3030"
+    volumes:
+      - .:/app
+      - web_node_modules_root:/app/node_modules
+      - web_node_modules_web:/app/apps/web/node_modules
+      - web_node_modules_types:/app/packages/module-types/node_modules
+      - web_node_modules_playground:/app/addons/ai-playground/node_modules
+      - web_node_modules_mcp_org:/app/mcp-servers/organization/node_modules
+      - web_next_cache:/app/apps/web/.next
+
   # AI RAG Backend (ChromaDB + sentence-transformers)
   airag-backend:
     build:
@@ -51,3 +93,9 @@ volumes:
   postgres_data:
   chroma_data:
   model_cache:
+  web_node_modules_root:
+  web_node_modules_web:
+  web_node_modules_types:
+  web_node_modules_playground:
+  web_node_modules_mcp_org:
+  web_next_cache:


### PR DESCRIPTION
## Summary
- Next.js 開発サーバを docker-compose スタックに組み込み、フルコンテナでの開発・他プロジェクトからのテスト利用を可能にした
- ポート `3030`（コンテナ/ホスト両方）で公開。ホスト側の `pnpm dev`（3000）と競合しない
- `postgres` / `airag-backend` と同一ネットワークでサービス名解決、env は compose で上書き（DB は `postgres:5432`、AUTH_URL は `http://localhost:3030`）

## 追加/変更ファイル
- `apps/web/Dockerfile.dev`: Node 20-slim + pnpm 10.6.5、ワークスペース manifest のみで `pnpm install` → Prisma Client 生成 → `next dev -H 0.0.0.0 -p 3030`
- `docker-compose.yml`: `web` サービス追加（depends_on で postgres ヘルス待機）
- `.dockerignore`: `node_modules` / `.next` / `chroma_data` / `model_cache` などをビルドコンテキストから除外
- ソースは bind mount でホットリロード（`WATCHPACK_POLLING=true`）、`node_modules` は named volume でホストと分離（macOS I/O 対策）

## 運用
```bash
docker compose up -d web          # 起動
docker compose logs -f web        # ログ追跡
docker compose stop web           # 停止
docker compose build web          # 再ビルド
```
アクセス: http://localhost:3030

## Test plan
- [x] `docker compose build web` が成功する
- [x] `docker compose up -d web` で `lionframe-web` が Ready になる
- [x] `curl http://localhost:3030/` が 307（`/login` リダイレクト）を返す
- [x] ブラウザからログインが成功する
- [ ] ホスト側の `pnpm dev` と同時起動してもポート競合しない
- [ ] `apps/web/` のソース変更がコンテナ内でホットリロードされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)