### PR TITLE
feat(oidc): 署名鍵未設定を authorize 段階で早期検出 + 管理画面で可視化

### DIFF
--- a/apps/web/__tests__/api/oidc/authorize.test.ts
+++ b/apps/web/__tests__/api/oidc/authorize.test.ts
@@ -40,12 +40,21 @@ jest.mock("jose", () => ({
   },
 }));
 
+const mockGetSigningKeyStatus = jest.fn(() =>
+  Promise.resolve({
+    ok: true as const,
+    activeKid: "k1",
+    keyCount: 1,
+    statusCounts: { active: 1, next: 0, retired: 0 },
+  }),
+);
 jest.mock("@/lib/services/oidc/keys", () => ({
   getActiveSigningKey: jest.fn(() =>
     Promise.resolve({ kid: "k1", privateKey: "p", publicKey: "q", publicJwk: {} }),
   ),
   findKeyByKid: jest.fn(),
   getPublicJwks: jest.fn(),
+  getSigningKeyStatus: () => mockGetSigningKeyStatus(),
 }));
 
 const mockPrisma = {
@@ -409,6 +418,37 @@ describe("Authorize エンドポイント契約", () => {
     expect(res.headers.get("set-cookie")).toMatch(/oidc_auth_req=/);
     expect(mockPrisma.oIDCAuthRequest.create).toHaveBeenCalled();
     // code は発行しない
+    expect(mockPrisma.oIDCAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  // ------------------ 署名鍵プレフライト ------------------
+
+  it("OIDC_SIGNING_KEYS 未設定で server_error を redirect + 監査ログ", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockGetSigningKeyStatus.mockResolvedValueOnce({
+      ok: false as unknown as true,
+      reason: "not_set" as unknown as never,
+      message:
+        "OIDC_SIGNING_KEYS is not set. Generate keys with `node apps/web/scripts/generate-oidc-keys.mjs` and add them to .env.",
+    } as never);
+
+    const { GET } = require("@/app/api/oidc/authorize/route");
+    const res = await GET(makeRequest(validParams));
+
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location") as string);
+    expect(loc.origin + loc.pathname).toBe("https://rp.example.lan/callback");
+    expect(loc.searchParams.get("error")).toBe("server_error");
+    expect(loc.searchParams.get("state")).toBe("state123");
+
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "OIDC_AUTHORIZE_SERVER_ERROR",
+        category: "OIDC",
+        details: expect.objectContaining({ reason: "not_set" }),
+      }),
+    );
+    // token endpoint 到達前に止まるので AuthCode は発行しない
     expect(mockPrisma.oIDCAuthCode.create).not.toHaveBeenCalled();
   });
 

--- a/apps/web/__tests__/api/oidc/authorize.test.ts
+++ b/apps/web/__tests__/api/oidc/authorize.test.ts
@@ -40,9 +40,11 @@ jest.mock("jose", () => ({
   },
 }));
 
-const mockGetSigningKeyStatus = jest.fn(() =>
+import type { SigningKeyStatus } from "@/lib/services/oidc/types";
+
+const mockGetSigningKeyStatus = jest.fn<Promise<SigningKeyStatus>, []>(() =>
   Promise.resolve({
-    ok: true as const,
+    ok: true,
     activeKid: "k1",
     keyCount: 1,
     statusCounts: { active: 1, next: 0, retired: 0 },
@@ -426,11 +428,11 @@ describe("Authorize エンドポイント契約", () => {
   it("OIDC_SIGNING_KEYS 未設定で server_error を redirect + 監査ログ", async () => {
     mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
     mockGetSigningKeyStatus.mockResolvedValueOnce({
-      ok: false as unknown as true,
-      reason: "not_set" as unknown as never,
+      ok: false,
+      reason: "not_set",
       message:
         "OIDC_SIGNING_KEYS is not set. Generate keys with `node apps/web/scripts/generate-oidc-keys.mjs` and add them to .env.",
-    } as never);
+    });
 
     const { GET } = require("@/app/api/oidc/authorize/route");
     const res = await GET(makeRequest(validParams));

--- a/apps/web/__tests__/lib/services/oidc/keys.test.ts
+++ b/apps/web/__tests__/lib/services/oidc/keys.test.ts
@@ -1,0 +1,73 @@
+/**
+ * OIDC keys - getSigningKeyStatus 単体テスト
+ *
+ * 検証対象:
+ * - OIDC_SIGNING_KEYS 未設定で reason="not_set"
+ * - 不正な JSON で reason="invalid"
+ * - 空配列で reason="invalid"
+ */
+
+// jose は ESM-only で Jest の transform 対象外。
+// 未設定/不正系のパスでは jose を呼ばないため空スタブで十分。
+jest.mock("jose", () => ({
+  importJWK: jest.fn(),
+  exportJWK: jest.fn(),
+}));
+
+import {
+  __resetKeyCacheForTest,
+  getSigningKeyStatus,
+} from "@/lib/services/oidc/keys";
+
+describe("getSigningKeyStatus", () => {
+  const originalEnv = process.env.OIDC_SIGNING_KEYS;
+
+  beforeEach(() => {
+    __resetKeyCacheForTest();
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) delete process.env.OIDC_SIGNING_KEYS;
+    else process.env.OIDC_SIGNING_KEYS = originalEnv;
+  });
+
+  it("未設定の場合 reason=not_set を返す", async () => {
+    delete process.env.OIDC_SIGNING_KEYS;
+    const result = await getSigningKeyStatus();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("not_set");
+      expect(result.message).toMatch(/OIDC_SIGNING_KEYS/);
+    }
+  });
+
+  it("空文字列の場合も reason=not_set を返す", async () => {
+    process.env.OIDC_SIGNING_KEYS = "";
+    const result = await getSigningKeyStatus();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not_set");
+  });
+
+  it("不正な JSON で reason=invalid を返す", async () => {
+    process.env.OIDC_SIGNING_KEYS = "{not json";
+    const result = await getSigningKeyStatus();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
+  });
+
+  it("空配列で reason=invalid を返す", async () => {
+    process.env.OIDC_SIGNING_KEYS = "[]";
+    const result = await getSigningKeyStatus();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
+  });
+
+  it("必須フィールド欠如で reason=invalid を返す", async () => {
+    process.env.OIDC_SIGNING_KEYS = JSON.stringify([
+      { kid: "k1", status: "active" }, // privateJwk / publicJwk 欠如
+    ]);
+    const result = await getSigningKeyStatus();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("invalid");
+  });
+});

--- a/apps/web/app/(main)/admin/oidc/clients/OidcClientsClient.tsx
+++ b/apps/web/app/(main)/admin/oidc/clients/OidcClientsClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { OIDCClient, Role } from "@prisma/client";
-import { MoreHorizontal } from "lucide-react";
+import { AlertTriangle, MoreHorizontal } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,6 +43,19 @@ interface OidcClientsClientProps {
   language: "en" | "ja";
 }
 
+type SigningKeyStatus =
+  | {
+      ok: true;
+      activeKid: string;
+      keyCount: number;
+      statusCounts: Record<"active" | "next" | "retired", number>;
+    }
+  | {
+      ok: false;
+      reason: "not_set" | "invalid" | "no_active";
+      message: string;
+    };
+
 function parseRedirectUris(input: string): string[] {
   return input
     .split(/\r?\n/)
@@ -73,6 +87,7 @@ export function OidcClientsClient({ language }: OidcClientsClientProps) {
   const t = oidcClientsTranslations[language];
   const [clients, setClients] = useState<OIDCClient[]>([]);
   const [loading, setLoading] = useState(true);
+  const [keyStatus, setKeyStatus] = useState<SigningKeyStatus | null>(null);
 
   const [formOpen, setFormOpen] = useState(false);
   const [formInitial, setFormInitial] = useState<ClientFormValues | undefined>();
@@ -104,6 +119,19 @@ export function OidcClientsClient({ language }: OidcClientsClientProps) {
   useEffect(() => {
     void loadClients();
   }, [loadClients]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/admin/oidc/signing-keys");
+        if (!res.ok) return;
+        const data = (await res.json()) as { status: SigningKeyStatus };
+        setKeyStatus(data.status);
+      } catch {
+        // 取得失敗時は警告を出さず沈黙（API 障害は別の経路で検知される）
+      }
+    })();
+  }, []);
 
   const handleOpenCreate = () => {
     setFormInitial(undefined);
@@ -212,8 +240,24 @@ export function OidcClientsClient({ language }: OidcClientsClientProps) {
     return <PageSkeleton />;
   }
 
+  const keyWarningBody =
+    keyStatus && !keyStatus.ok
+      ? keyStatus.reason === "not_set"
+        ? t.signingKeysWarningNotSet
+        : keyStatus.reason === "no_active"
+          ? t.signingKeysWarningNoActive
+          : `${t.signingKeysWarningInvalid} ${keyStatus.message}`
+      : null;
+
   return (
     <div className="space-y-6">
+      {keyWarningBody && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertTitle>{t.signingKeysWarningTitle}</AlertTitle>
+          <AlertDescription>{keyWarningBody}</AlertDescription>
+        </Alert>
+      )}
       <Card>
         <CardHeader className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <CardDescription className="max-w-3xl">

--- a/apps/web/app/(main)/admin/oidc/clients/OidcClientsClient.tsx
+++ b/apps/web/app/(main)/admin/oidc/clients/OidcClientsClient.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import type { SigningKeyStatus } from "@/lib/services/oidc/types";
 import {
   Card,
   CardContent,
@@ -42,19 +43,6 @@ import { oidcClientsTranslations } from "./translations";
 interface OidcClientsClientProps {
   language: "en" | "ja";
 }
-
-type SigningKeyStatus =
-  | {
-      ok: true;
-      activeKid: string;
-      keyCount: number;
-      statusCounts: Record<"active" | "next" | "retired", number>;
-    }
-  | {
-      ok: false;
-      reason: "not_set" | "invalid" | "no_active";
-      message: string;
-    };
 
 function parseRedirectUris(input: string): string[] {
   return input

--- a/apps/web/app/(main)/admin/oidc/clients/translations.ts
+++ b/apps/web/app/(main)/admin/oidc/clients/translations.ts
@@ -79,6 +79,15 @@ export const oidcClientsTranslations = {
     deleteError: "Failed to delete OIDC client",
     regenerateError: "Failed to regenerate secret",
     validationError: "Please fill in all required fields",
+
+    // Signing keys warning
+    signingKeysWarningTitle: "OIDC signing keys are not configured",
+    signingKeysWarningNotSet:
+      "OIDC_SIGNING_KEYS is not set. Clients cannot obtain ID tokens until keys are generated. Run `node apps/web/scripts/generate-oidc-keys.mjs` and add the output to the provider's .env, then restart the app.",
+    signingKeysWarningInvalid:
+      "OIDC_SIGNING_KEYS is set but not usable. Details:",
+    signingKeysWarningNoActive:
+      "No signing key has status=\"active\". Generate a new key with status=active via generate-oidc-keys.mjs.",
   },
   ja: {
     title: "OIDC クライアント",
@@ -153,6 +162,15 @@ export const oidcClientsTranslations = {
     deleteError: "OIDC クライアントの削除に失敗しました",
     regenerateError: "シークレットの再生成に失敗しました",
     validationError: "必須項目を入力してください",
+
+    // Signing keys warning
+    signingKeysWarningTitle: "OIDC 署名鍵が設定されていません",
+    signingKeysWarningNotSet:
+      "OIDC_SIGNING_KEYS が未設定です。このままではクライアントは ID トークンを取得できません。`node apps/web/scripts/generate-oidc-keys.mjs` を実行し、出力を Provider 側の .env に追記してアプリを再起動してください。",
+    signingKeysWarningInvalid:
+      "OIDC_SIGNING_KEYS は設定されていますが使用できない状態です。詳細:",
+    signingKeysWarningNoActive:
+      "status=\"active\" の鍵がありません。generate-oidc-keys.mjs で active 状態の鍵を生成してください。",
   },
 };
 

--- a/apps/web/app/api/admin/oidc/signing-keys/route.ts
+++ b/apps/web/app/api/admin/oidc/signing-keys/route.ts
@@ -1,0 +1,10 @@
+import { apiHandler } from "@/lib/api/api-handler";
+import { getSigningKeyStatus } from "@/lib/services/oidc/keys";
+
+export const GET = apiHandler(
+  async () => {
+    const status = await getSigningKeyStatus();
+    return { status };
+  },
+  { admin: true },
+);

--- a/apps/web/app/api/oidc/authorize/route.ts
+++ b/apps/web/app/api/oidc/authorize/route.ts
@@ -11,6 +11,7 @@ import {
   OIDC_SUPPORTED_RESPONSE_TYPES,
 } from "@/lib/services/oidc/constants";
 import { oidcErrorRedirect } from "@/lib/services/oidc/errors";
+import { getSigningKeyStatus } from "@/lib/services/oidc/keys";
 import { signValue } from "@/lib/services/cookie-signer";
 import { checkRateLimit, getClientIp } from "@/lib/services/rate-limiter";
 
@@ -180,6 +181,29 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   if (!clientRow) {
     return jsonError("invalid_client", "Client not found");
+  }
+
+  // 署名鍵プレフライト: 鍵未設定なら token endpoint 到達前に失敗させる。
+  // これが無いと RP のコールバックで token 500 になり切り分けが困難になる。
+  const keyStatus = await getSigningKeyStatus();
+  if (!keyStatus.ok) {
+    console.error(
+      `[OIDC] authorize aborted: signing keys unusable (${keyStatus.reason}): ${keyStatus.message}`,
+    );
+    await AuditService.log({
+      action: "OIDC_AUTHORIZE_SERVER_ERROR",
+      category: "OIDC",
+      targetId: clientRow.id,
+      targetType: "OIDCClient",
+      details: { reason: keyStatus.reason, message: keyStatus.message },
+      ipAddress: ip,
+    });
+    return oidcErrorRedirect(
+      redirectUri,
+      "server_error",
+      "OIDC signing keys are not configured on the provider",
+      state ?? undefined,
+    );
   }
 
   // セッション確認

--- a/apps/web/lib/services/audit-service.ts
+++ b/apps/web/lib/services/audit-service.ts
@@ -98,6 +98,7 @@ export type AuditAction =
   // OIDC（Issue #6 でフレーム本体の認証基盤拡張として追加）
   | "OIDC_AUTHORIZE"
   | "OIDC_AUTHORIZE_DENIED"
+  | "OIDC_AUTHORIZE_SERVER_ERROR"
   | "OIDC_CONSENT_GRANT"
   | "OIDC_TOKEN_ISSUE"
   | "OIDC_TOKEN_REUSE_DETECTED"

--- a/apps/web/lib/services/oidc/keys.ts
+++ b/apps/web/lib/services/oidc/keys.ts
@@ -7,6 +7,9 @@
 //   - 検証（token 再利用検知等）は kid で直接 lookup
 
 import { type JWK, importJWK } from "jose";
+import type { SigningKeyStatus } from "./types";
+
+export type { SigningKeyStatus } from "./types";
 
 type SigningKey = CryptoKey | Uint8Array;
 
@@ -103,19 +106,6 @@ export async function findKeyByKid(kid: string): Promise<LoadedKey | null> {
 export function __resetKeyCacheForTest(): void {
   cachedKeys = null;
 }
-
-export type SigningKeyStatus =
-  | {
-      ok: true;
-      activeKid: string;
-      keyCount: number;
-      statusCounts: Record<KeyStatus, number>;
-    }
-  | {
-      ok: false;
-      reason: "not_set" | "invalid" | "no_active";
-      message: string;
-    };
 
 /**
  * 環境変数ベースの署名鍵の健全性を確認する。

--- a/apps/web/lib/services/oidc/keys.ts
+++ b/apps/web/lib/services/oidc/keys.ts
@@ -103,3 +103,62 @@ export async function findKeyByKid(kid: string): Promise<LoadedKey | null> {
 export function __resetKeyCacheForTest(): void {
   cachedKeys = null;
 }
+
+export type SigningKeyStatus =
+  | {
+      ok: true;
+      activeKid: string;
+      keyCount: number;
+      statusCounts: Record<KeyStatus, number>;
+    }
+  | {
+      ok: false;
+      reason: "not_set" | "invalid" | "no_active";
+      message: string;
+    };
+
+/**
+ * 環境変数ベースの署名鍵の健全性を確認する。
+ * throw せず、UI や preflight 用に状態オブジェクトを返す。
+ */
+export async function getSigningKeyStatus(): Promise<SigningKeyStatus> {
+  const raw = process.env.OIDC_SIGNING_KEYS;
+  if (!raw || raw.trim() === "") {
+    return {
+      ok: false,
+      reason: "not_set",
+      message:
+        "OIDC_SIGNING_KEYS is not set. Generate keys with `node apps/web/scripts/generate-oidc-keys.mjs` and add them to .env.",
+    };
+  }
+  try {
+    const keys = await loadKeys();
+    const counts: Record<KeyStatus, number> = {
+      active: 0,
+      next: 0,
+      retired: 0,
+    };
+    for (const k of keys) counts[k.status]++;
+    const active = keys.find((k) => k.status === "active");
+    if (!active) {
+      return {
+        ok: false,
+        reason: "no_active",
+        message:
+          "No OIDC signing key with status=active. Rotate via generate-oidc-keys.mjs.",
+      };
+    }
+    return {
+      ok: true,
+      activeKid: active.kid,
+      keyCount: keys.length,
+      statusCounts: counts,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "invalid",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/web/lib/services/oidc/types.ts
+++ b/apps/web/lib/services/oidc/types.ts
@@ -1,0 +1,18 @@
+// OIDC 関連の共有型定義。
+// keys.ts は `jose` を import するためクライアントコンポーネントから
+// 直接 import させたくない。型だけこちらに切り出す。
+
+export type SigningKeyStatusReason = "not_set" | "invalid" | "no_active";
+
+export type SigningKeyStatus =
+  | {
+      ok: true;
+      activeKid: string;
+      keyCount: number;
+      statusCounts: Record<"active" | "next" | "retired", number>;
+    }
+  | {
+      ok: false;
+      reason: SigningKeyStatusReason;
+      message: string;
+    };


### PR DESCRIPTION
## Summary

- `OIDC_SIGNING_KEYS` 未設定時の検知タイミングを、token endpoint の 500 から **authorize の 302 redirect + 管理画面バナー** に前倒し
- RP 開発者はコールバックの `error=server_error` で即座に原因に気付ける / Provider 側は監査ログ `OIDC_AUTHORIZE_SERVER_ERROR` + `console.error` で検知
- ADMIN は `/admin/oidc/clients` 上部のバナーで恒常的に鍵未設定を視認できる

## 背景

RP 側（別プロジェクト）で OIDC 連携をデバッグ中に、Provider 側の `OIDC_SIGNING_KEYS` 未設定が判明。これまでは:

- authorize は 302 で通過 → consent 完了 → RP コールバックの **token 交換で 500** という導線
- RP 側ログからは LionFrame 内部が分からず切り分けに時間がかかる

## 変更内容

### 1. authorize プレフライト
- `lib/services/oidc/keys.ts`: `getSigningKeyStatus()` を追加（throw せず `{ ok, reason }` を返す）
- `app/api/oidc/authorize/route.ts`: `redirect_uri` 確定直後にプレフライト呼出、鍵不在時は `server_error` で redirect + 監査ログ
- `lib/services/audit-service.ts`: `OIDC_AUTHORIZE_SERVER_ERROR` アクションを追加

### 2. 管理画面バナー
- `app/api/admin/oidc/signing-keys/route.ts`: ADMIN 専用 GET で状態を返す
- `app/(main)/admin/oidc/clients/OidcClientsClient.tsx`: 3 状態（`not_set` / `invalid` / `no_active`）を日英で表示する destructive Alert を追加

### 3. テスト
- `__tests__/lib/services/oidc/keys.test.ts`（新規・5 件）: `getSigningKeyStatus` の未設定・不正 JSON・空配列・必須欠如
- `__tests__/api/oidc/authorize.test.ts`: プレフライトで `server_error` + 監査ログが出るケースを追加

## Test plan

- [x] `pnpm --filter @lionframe/web test __tests__/api/oidc __tests__/lib/services/oidc` で全 73 件 PASS
- [x] 変更ファイルの `tsc --noEmit` クリーン
- [ ] 手動確認: `.env` から `OIDC_SIGNING_KEYS` を外した状態で RP から authorize を叩き、redirect_uri に `error=server_error` が返ることを確認
- [ ] 手動確認: 同状態で `/admin/oidc/clients` に警告バナーが表示されることを確認
- [ ] 手動確認: 鍵を再設定すると両方が正常に戻ることを確認

## 備考

- Biome lint はローカルで `apps/web に .gitignore が無い`ため走らないが、これは既存の設定起因で本 PR とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)