### PR TITLE
chore(docker): web サービスで apps/web/.env を env_file として読み込む

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,14 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # apps/web/.env を env_file として読み込み、OIDC_SIGNING_KEYS や VAPID キー
+    # など Next.js アプリ側で設定済みの秘匿情報をそのままコンテナに渡す。
+    # Compose の優先順位上、environment に明記したキー（DB URL / AUTH_URL /
+    # OIDC_ISSUER など、コンテナ内ネットワーク前提で上書きが必要なもの）は
+    # env_file より強い。
+    env_file:
+      - path: ./apps/web/.env
+        required: false
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://lionframe:lionframe@postgres:5432/lionframe?schema=public
@@ -38,14 +46,11 @@ services:
       # 生成例: openssl rand -base64 32
       AUTH_SECRET: ${AUTH_SECRET:-dev-secret-change-me}
       OIDC_ISSUER: http://localhost:3030
-      OIDC_SIGNING_KEYS: ${OIDC_SIGNING_KEYS:-}
       RAG_BACKEND_URL: http://airag-backend:8000
       LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:8080}
       NEXT_PUBLIC_APP_NAME: LionFrame
       NEXT_PUBLIC_APP_DESCRIPTION: Modular framework for back-office operations
       NEXT_PUBLIC_APP_DESCRIPTION_JA: バックオフィス業務を支援するモジュラーフレームワーク
-      NEXT_PUBLIC_VAPID_PUBLIC_KEY: ${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}
-      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
       NEXT_PUBLIC_WEBAUTHN_RP_ID: localhost
       NEXT_PUBLIC_WEBAUTHN_RP_NAME: LionFrame
       WEBAUTHN_ORIGIN: http://localhost:3030


### PR DESCRIPTION
## Summary

- Docker Compose の \`web\` サービスに \`env_file: ./apps/web/.env\` を追加。\`apps/web/.env\` に設定済みの秘匿情報（OIDC_SIGNING_KEYS / VAPID キー等）がそのままコンテナに渡る
- 間接参照 \`${OIDC_SIGNING_KEYS:-}\` / \`${NEXT_PUBLIC_VAPID_PUBLIC_KEY:-}\` / \`${VAPID_PRIVATE_KEY:-}\` を削除（空文字で上書きされていた）
- コンテナ内ネットワーク前提のキー（DATABASE_URL / AUTH_URL / OIDC_ISSUER / WEBAUTHN_ORIGIN）は \`environment\` に残し、Compose の優先順位で env_file を上書き

## 背景

PR #22 で追加した「署名鍵未設定バナー」がローカルで常時表示される事象があり、原因を追跡したところ:

1. ユーザは \`apps/web/.env\` に OIDC_SIGNING_KEYS を正しく設定済み
2. しかし \`docker-compose.yml\` は \`${OIDC_SIGNING_KEYS:-}\` でルート直下 \`.env\` / シェル環境変数のみ参照する構成
3. ルートに \`.env\` が無いと空文字がコンテナに渡り、authorize プレフライト + 管理画面バナーが作動してしまう

本 PR で \`env_file\` を導入すれば \`apps/web/.env\` が単一のソース・オブ・トゥルースになり、この二重管理が解消される。

## Test plan

- [x] \`docker compose config\` で構文確認
- [x] ルート \`.env\` を退避した状態で \`docker compose up -d web\` → コンテナ内の OIDC_SIGNING_KEYS が 2157 バイト（= apps/web/.env の値）になることを検証
- [ ] 既存ユーザの \`.env\` 運用が壊れないこと（required: false 指定のため \`apps/web/.env\` が無くても起動は可能）

## 備考

- \`AUTH_SECRET\` は \`${AUTH_SECRET:-dev-secret-change-me}\` のデフォルト付きフォールバックを維持（初見 dev 体験のため）
- 既存の DATABASE_URL 等のコンテナ内上書きは保持。\`apps/web/.env\` 側の \`localhost:5433\` 等は env_file 経由で読み込まれるが environment で上書きされるため実害なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)