### PR TITLE
fix(oidc): authorize リダイレクトを AUTH_URL 基準に固定 (Issue #24)

### DIFF
--- a/apps/web/__tests__/api/oidc/authorize.test.ts
+++ b/apps/web/__tests__/api/oidc/authorize.test.ts
@@ -425,6 +425,59 @@ describe("Authorize エンドポイント契約", () => {
 
   // ------------------ 署名鍵プレフライト ------------------
 
+  // ------------------ Issue #24: リダイレクト先オリジン ------------------
+
+  it("AUTH_URL が設定されていれば /login リダイレクトで AUTH_URL のオリジンを使う（0.0.0.0 問題の修正）", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(null);
+
+    const prevAuthUrl = process.env.AUTH_URL;
+    process.env.AUTH_URL = "http://localhost:3030";
+
+    try {
+      const { GET } = require("@/app/api/oidc/authorize/route");
+      // dev server の 0.0.0.0 bind を模した request
+      const url = `http://0.0.0.0:3030/api/oidc/authorize?${new URLSearchParams(
+        validParams,
+      ).toString()}`;
+      const res = await GET(
+        new Request(url, { method: "GET", headers: {} }),
+      );
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") as string);
+      expect(loc.origin).toBe("http://localhost:3030");
+      expect(loc.pathname).toBe("/login");
+    } finally {
+      if (prevAuthUrl === undefined) delete process.env.AUTH_URL;
+      else process.env.AUTH_URL = prevAuthUrl;
+    }
+  });
+
+  it("AUTH_URL 設定時は /oidc/consent リダイレクトも AUTH_URL のオリジンを使う", async () => {
+    mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
+    mockAuth.mockResolvedValue(userSession("USER"));
+
+    const prevAuthUrl = process.env.AUTH_URL;
+    process.env.AUTH_URL = "http://localhost:3030";
+
+    try {
+      const { GET } = require("@/app/api/oidc/authorize/route");
+      const url = `http://0.0.0.0:3030/api/oidc/authorize?${new URLSearchParams(
+        validParams,
+      ).toString()}`;
+      const res = await GET(
+        new Request(url, { method: "GET", headers: {} }),
+      );
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") as string);
+      expect(loc.origin).toBe("http://localhost:3030");
+      expect(loc.pathname).toBe("/oidc/consent");
+    } finally {
+      if (prevAuthUrl === undefined) delete process.env.AUTH_URL;
+      else process.env.AUTH_URL = prevAuthUrl;
+    }
+  });
+
   it("OIDC_SIGNING_KEYS 未設定で server_error を redirect + 監査ログ", async () => {
     mockPrisma.oIDCClient.findUnique.mockResolvedValue(validClient());
     mockGetSigningKeyStatus.mockResolvedValueOnce({

--- a/apps/web/__tests__/lib/api/base-url.test.ts
+++ b/apps/web/__tests__/lib/api/base-url.test.ts
@@ -83,6 +83,17 @@ describe("getRequestBaseUrl", () => {
     expect(getRequestBaseUrl(req)).toBe("http://app.example.com");
   });
 
+  it("x-forwarded-proto が http/https 以外なら AUTH_URL を使う（危険スキーム排除）", () => {
+    process.env.AUTH_URL = "http://app.example.com";
+    const req = buildReq({
+      headers: {
+        "x-forwarded-proto": "javascript",
+        "x-forwarded-host": "app.example.com",
+      },
+    });
+    expect(getRequestBaseUrl(req)).toBe("http://app.example.com");
+  });
+
   it("AUTH_URL 未設定時は nextUrl.origin にフォールバック", () => {
     delete process.env.AUTH_URL;
     const req = buildReq({

--- a/apps/web/__tests__/lib/api/base-url.test.ts
+++ b/apps/web/__tests__/lib/api/base-url.test.ts
@@ -1,0 +1,100 @@
+/**
+ * getRequestBaseUrl ヘルパーのテスト
+ *
+ * 検証対象:
+ * - AUTH_URL が最優先
+ * - x-forwarded-host が AUTH_URL のホストと一致した場合のみ forwarded を使う
+ * - AUTH_URL 未設定時は request の origin にフォールバック
+ * - dev server 0.0.0.0 問題 (Issue #24) の再現 → 修正
+ */
+
+import { getRequestBaseUrl } from "@/lib/api/base-url";
+
+function buildReq(opts: {
+  url?: string;
+  headers?: Record<string, string>;
+  nextUrlOrigin?: string;
+}) {
+  const headers = opts.headers ?? {};
+  return {
+    url: opts.url ?? "http://localhost:3030/",
+    headers: {
+      get(name: string) {
+        return headers[name.toLowerCase()] ?? null;
+      },
+    },
+    ...(opts.nextUrlOrigin
+      ? { nextUrl: { origin: opts.nextUrlOrigin } }
+      : {}),
+  };
+}
+
+describe("getRequestBaseUrl", () => {
+  const originalAuthUrl = process.env.AUTH_URL;
+
+  afterEach(() => {
+    if (originalAuthUrl === undefined) delete process.env.AUTH_URL;
+    else process.env.AUTH_URL = originalAuthUrl;
+  });
+
+  it("AUTH_URL が最優先される（request の origin は無視）", () => {
+    process.env.AUTH_URL = "http://localhost:3030";
+    const req = buildReq({
+      url: "http://0.0.0.0:3030/api/oidc/authorize",
+      nextUrlOrigin: "http://0.0.0.0:3030",
+    });
+    expect(getRequestBaseUrl(req)).toBe("http://localhost:3030");
+  });
+
+  it("AUTH_URL 末尾のスラッシュは除去される", () => {
+    process.env.AUTH_URL = "http://localhost:3030/";
+    const req = buildReq({});
+    expect(getRequestBaseUrl(req)).toBe("http://localhost:3030");
+  });
+
+  it("Issue #24: dev server 0.0.0.0 bind でも AUTH_URL が効くことを確認", () => {
+    process.env.AUTH_URL = "http://localhost:3030";
+    const req = buildReq({
+      url: "http://0.0.0.0:3030/api/oidc/authorize?response_type=code",
+      nextUrlOrigin: "http://0.0.0.0:3030",
+    });
+    expect(getRequestBaseUrl(req)).toBe("http://localhost:3030");
+  });
+
+  it("x-forwarded-host が AUTH_URL と一致すれば forwarded を優先", () => {
+    process.env.AUTH_URL = "http://app.example.com";
+    const req = buildReq({
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "app.example.com",
+      },
+    });
+    expect(getRequestBaseUrl(req)).toBe("https://app.example.com");
+  });
+
+  it("x-forwarded-host が AUTH_URL と不一致なら AUTH_URL を使う（spoofing 防止）", () => {
+    process.env.AUTH_URL = "http://app.example.com";
+    const req = buildReq({
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "evil.example.com",
+      },
+    });
+    expect(getRequestBaseUrl(req)).toBe("http://app.example.com");
+  });
+
+  it("AUTH_URL 未設定時は nextUrl.origin にフォールバック", () => {
+    delete process.env.AUTH_URL;
+    const req = buildReq({
+      url: "http://localhost:3030/x",
+      nextUrlOrigin: "http://localhost:3030",
+    });
+    expect(getRequestBaseUrl(req)).toBe("http://localhost:3030");
+  });
+
+  it("AUTH_URL 未設定 + nextUrl なしなら request.url の origin を使う", () => {
+    delete process.env.AUTH_URL;
+    const req = buildReq({ url: "http://localhost:3030/foo" });
+    expect(getRequestBaseUrl(req)).toBe("http://localhost:3030");
+  });
+});

--- a/apps/web/__tests__/lib/security/security-audit.test.ts
+++ b/apps/web/__tests__/lib/security/security-audit.test.ts
@@ -27,8 +27,13 @@ describe("セキュリティ静的検証", () => {
   });
 
   describe("x-forwarded-host 信頼制限", () => {
-    it("middleware.ts で AUTH_URL に対する検証があること", () => {
+    it("middleware.ts が共通ヘルパー getRequestBaseUrl 経由でオリジンを決定していること", () => {
       const source = readSource("middleware.ts");
+      expect(source).toContain("getRequestBaseUrl");
+    });
+
+    it("lib/api/base-url.ts で AUTH_URL と trustedHost 検証が実装されていること", () => {
+      const source = readSource("lib/api/base-url.ts");
       expect(source).toContain("AUTH_URL");
       expect(source).toContain("trustedHost");
     });

--- a/apps/web/app/api/oidc/authorize/route.ts
+++ b/apps/web/app/api/oidc/authorize/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
+import { getRequestBaseUrl } from "@/lib/api/base-url";
 import { verifySignedValue } from "@/lib/services/cookie-signer";
 import { AuditService } from "@/lib/services/audit-service";
 import { OIDCClientService } from "@/lib/services/oidc/client-service";
@@ -228,7 +229,10 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
     const cookie = await buildAuthRequestCookie(handle);
     const callbackUrl = `/api/oidc/authorize?resume=${encodeURIComponent(handle)}`;
-    const loginUrl = new URL("/login", url.origin);
+    // dev server が 0.0.0.0 bind のため url.origin ではなく AUTH_URL 基準で
+    // 組み立てる。これをしないとブラウザは別オリジン扱いして WebAuthn /
+    // パスキーが発火しない（Issue #24）。
+    const loginUrl = new URL("/login", getRequestBaseUrl(request));
     loginUrl.searchParams.set("callbackUrl", callbackUrl);
     return NextResponse.redirect(loginUrl.toString(), {
       status: 302,
@@ -349,7 +353,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     handle = saved.id;
   }
   const cookie = await buildAuthRequestCookie(handle);
-  const consentUrl = new URL("/oidc/consent", url.origin);
+  const consentUrl = new URL("/oidc/consent", getRequestBaseUrl(request));
   return NextResponse.redirect(consentUrl.toString(), {
     status: 302,
     headers: { "Set-Cookie": cookie },

--- a/apps/web/lib/api/base-url.ts
+++ b/apps/web/lib/api/base-url.ts
@@ -17,13 +17,22 @@ type MinimalRequest = {
   nextUrl?: { origin: string };
 };
 
+// x-forwarded-proto は http/https のみ許容する。攻撃者がリバースプロキシより
+// 手前でヘッダを注入できる環境で javascript: 等の危険なスキームが
+// 混入するのを防ぐ。
+const ALLOWED_FORWARDED_PROTOS: ReadonlySet<string> = new Set(["http", "https"]);
+
 export function getRequestBaseUrl(request: MinimalRequest): string {
   const authUrl = process.env.AUTH_URL;
   const forwardedProto = request.headers.get("x-forwarded-proto");
   const forwardedHost = request.headers.get("x-forwarded-host");
 
   if (authUrl) {
-    if (forwardedProto && forwardedHost) {
+    if (
+      forwardedProto &&
+      forwardedHost &&
+      ALLOWED_FORWARDED_PROTOS.has(forwardedProto)
+    ) {
       try {
         const trustedHost = new URL(authUrl).host;
         if (forwardedHost === trustedHost) {

--- a/apps/web/lib/api/base-url.ts
+++ b/apps/web/lib/api/base-url.ts
@@ -1,0 +1,42 @@
+// リクエストからリダイレクト基準となる origin を取得する。
+//
+// Next.js 15 の dev server は 0.0.0.0 で bind するため、Route Handler 内で
+// `new URL(request.url).origin` を使うと `http://0.0.0.0:3030` になる。これで
+// `/login` にリダイレクトするとブラウザからは localhost:3030 と別オリジン
+// として扱われ、WebAuthn / パスキーが発火しない（Issue #24）。
+//
+// 優先順位:
+//   1. AUTH_URL（NextAuth 標準、ブラウザから見えるオリジンを記述する想定）
+//   2. x-forwarded-proto + x-forwarded-host（AUTH_URL のホストと一致する場合のみ、
+//      リバースプロキシ経由の spoofing 防止）
+//   3. request からパースした origin（テスト用フォールバック）
+
+type MinimalRequest = {
+  headers: { get(name: string): string | null };
+  url: string;
+  nextUrl?: { origin: string };
+};
+
+export function getRequestBaseUrl(request: MinimalRequest): string {
+  const authUrl = process.env.AUTH_URL;
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const forwardedHost = request.headers.get("x-forwarded-host");
+
+  if (authUrl) {
+    if (forwardedProto && forwardedHost) {
+      try {
+        const trustedHost = new URL(authUrl).host;
+        if (forwardedHost === trustedHost) {
+          return `${forwardedProto}://${forwardedHost}`;
+        }
+      } catch {
+        // AUTH_URL が不正なら以降のフォールバックへ
+      }
+    }
+    return authUrl.replace(/\/$/, "");
+  }
+
+  // AUTH_URL 未設定時のフォールバック（主にテスト用）
+  if (request.nextUrl?.origin) return request.nextUrl.origin;
+  return new URL(request.url).origin;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import NextAuth from "next-auth";
 import { authConfig } from "@/auth.config";
+import { getRequestBaseUrl } from "@/lib/api/base-url";
 import { sanitizeCallbackUrl } from "@/lib/services/safe-redirect";
 
 const { auth } = NextAuth(authConfig);
@@ -26,18 +27,10 @@ export default auth(async (req) => {
 
   const session = req.auth;
 
-  // Reverse proxy support: construct correct redirect base URL
-  // Validate x-forwarded-host against AUTH_URL to prevent host header injection
-  const authUrl = process.env.AUTH_URL;
-  const forwardedProto = req.headers.get("x-forwarded-proto");
-  const forwardedHost = req.headers.get("x-forwarded-host");
-  let baseUrl = req.nextUrl.origin;
-  if (forwardedProto && forwardedHost && authUrl) {
-    const trustedHost = new URL(authUrl).host;
-    if (forwardedHost === trustedHost) {
-      baseUrl = `${forwardedProto}://${forwardedHost}`;
-    }
-  }
+  // AUTH_URL 基準でリダイレクト URL を組み立てる。dev server の 0.0.0.0 bind
+  // 問題 (Issue #24) + リバースプロキシ経由の x-forwarded-host spoofing 対策
+  // を共通ヘルパーで一元化。
+  const baseUrl = getRequestBaseUrl(req);
   const redirectUrl = (path: string) => new URL(path, baseUrl);
 
   // Build ID mismatch helper

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -177,7 +177,7 @@ export default auth(async (req) => {
   const excludedLogPaths = ["/login", "/auth/", "/settings", "/_next/", "/api/"];
   const shouldLog = !excludedLogPaths.some((p) => pathname.startsWith(p));
   if (shouldLog && session.user?.id) {
-    const logUrl = new URL("/api/usage-log", req.nextUrl.origin);
+    const logUrl = new URL("/api/usage-log", baseUrl);
     fetch(logUrl, {
       method: "POST",
       headers: {


### PR DESCRIPTION
Closes #24

## Summary

- `/api/oidc/authorize` からの `/login` / `/oidc/consent` へのリダイレクトで `Location` ヘッダが `http://0.0.0.0:3030/...` になっていた問題を修正
- ブラウザはこれを `localhost:3030` と別オリジンと解釈し、WebAuthn / パスキーが OIDC 経由のログインフローで発火しなかった
- 共通ヘルパー `getRequestBaseUrl` を新設し、`AUTH_URL` 最優先 + `x-forwarded-host` spoofing 防止を一箇所に集約

## 背景

Next.js 15 の dev server は `0.0.0.0` で bind するため、Route Handler 内で `new URL(request.url).origin` が `http://0.0.0.0:3030` になる。これをそのまま `/login` の URL 組み立てに使っていたのがバグ。

Issue #24 は `loginUrl` のみ指摘していたが、同ファイル内の `consentUrl` も同じバグを持っていたため **両方修正**。また `middleware.ts` には既に類似のロジックがあったが挙動が微妙に異なる（AUTH_URL があっても forwarded がなければ `req.nextUrl.origin` を使う → 0.0.0.0 問題を引く）ため、同じヘルパーに統一。

## 変更内容

| ファイル | 変更 |
|----------|------|
| `lib/api/base-url.ts` | 新設。AUTH_URL 優先 + forwarded spoofing 防止付きの `getRequestBaseUrl` |
| `app/api/oidc/authorize/route.ts` | `loginUrl` / `consentUrl` をヘルパー経由に |
| `middleware.ts` | 既存の baseUrl 構築ロジックをヘルパー呼び出し 1 行に統合 |
| `__tests__/lib/api/base-url.test.ts` | 新設（7 件） |
| `__tests__/api/oidc/authorize.test.ts` | AUTH_URL 優先の契約テストを追加（2 件） |
| `__tests__/lib/security/security-audit.test.ts` | trustedHost 検証の対象を middleware → base-url.ts に追従 |

## Test plan

- [x] `pnpm jest` 全 297 件 PASS
- [x] `tsc --noEmit` クリーン
- [x] 実機検証: `docker exec` 経由で authorize を叩き、`Location: http://localhost:3030/login?...`（修正後）を確認（修正前は `http://0.0.0.0:3030/...`）
- [ ] 実ブラウザで OIDC RP 経由のログイン → パスキーダイアログ発火を確認
- [ ] 既存の main 画面遷移（未認証で /dashboard → /login 302）が引き続き正しく動作することを確認

## 補足: Issue の提案精査

- 提案 1（authorize の loginUrl を AUTH_URL 基準に固定）→ 採用。ただし `consentUrl` も同バグだったので拡張
- 提案 2（dev server の `-H localhost`）→ 採用せず。staging/prod で外部ホスト名を使うケースに対応不能なため、根本解決は 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)