### PR TITLE
fix(auth): 内部API呼び出しのbaseURLにAUTH_URLフォールバックを追加 (Issue #28)

### DIFF
--- a/apps/web/app/api/admin/diagnostics/route.ts
+++ b/apps/web/app/api/admin/diagnostics/route.ts
@@ -157,7 +157,7 @@ export const POST = apiHandler(async (_request, session) => {
 
     // 5. API Health
     runDiagnostic("api_health", "API Health", "API応答", async () => {
-      const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+      const baseUrl = process.env.NEXTAUTH_URL || process.env.AUTH_URL || "http://localhost:3000";
       const response = await fetch(`${baseUrl}/api/health`);
       if (response.status === 200) {
         return {

--- a/apps/web/app/api/admin/modules/health/route.ts
+++ b/apps/web/app/api/admin/modules/health/route.ts
@@ -40,7 +40,7 @@ async function checkContainerHealth(
         // 内部APIパスの場合はサーバー内で直接フェッチ
         const url = healthCheckUrl.startsWith("http")
           ? healthCheckUrl
-          : `${process.env.NEXTAUTH_URL || "http://localhost:3000"}${healthCheckUrl}`;
+          : `${process.env.NEXTAUTH_URL || process.env.AUTH_URL || "http://localhost:3000"}${healthCheckUrl}`;
 
         const res = await fetch(url, {
           signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),

--- a/apps/web/app/api/admin/modules/route.ts
+++ b/apps/web/app/api/admin/modules/route.ts
@@ -72,7 +72,7 @@ export const GET = apiHandler(async () => {
           if (healthCheckUrl) {
             const url = healthCheckUrl.startsWith("http")
               ? healthCheckUrl
-              : `${process.env.NEXTAUTH_URL || "http://localhost:3000"}${healthCheckUrl}`;
+              : `${process.env.NEXTAUTH_URL || process.env.AUTH_URL || "http://localhost:3000"}${healthCheckUrl}`;
             const res = await fetch(url, {
               signal: AbortSignal.timeout(5000),
             });


### PR DESCRIPTION
## Summary
- Auth.js v5（`AUTH_URL`）への移行漏れで、内部 API 自己呼び出しの baseURL が `NEXTAUTH_URL` のみフォールバックしていた問題を修正
- フォールバック順を `NEXTAUTH_URL → AUTH_URL → http://localhost:3000` に統一
- 影響3ファイル: `apps/web/app/api/admin/modules/route.ts` / `apps/web/app/api/admin/modules/health/route.ts` / `apps/web/app/api/admin/diagnostics/route.ts`

Closes #28

## Test plan
- [ ] `apps/web/.env` に `AUTH_URL=http://localhost:3030` を設定し `NEXTAUTH_URL` 未設定で開発サーバを 3030 番で起動
- [ ] `/admin?tab=system` のモジュールヘルスで RAG コンテナ等のオプションコンテナが「停止中」と誤判定されないこと
- [ ] `/admin?tab=diagnostics` の API Health チェックが pass になること
- [ ] `NEXTAUTH_URL` を設定した既存環境でも従来通り動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)