### PR TITLE
fix(header): /login での useSidebar クラッシュを防止 (Issue #29)

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -514,7 +514,10 @@ function HeaderFallback({ language = "en" }: { language?: string }) {
  * ない場合は SidebarProvider 不要の HeaderFallback を表示する。
  */
 export function Header(props: HeaderProps) {
-  if (!props.session) {
+  const pathname = usePathname();
+  // ClientLayout は /login で SidebarProvider をスキップするため、
+  // セッションが残っていても HeaderInner（useSidebar 必須）は使えない。
+  if (!props.session || pathname === "/login") {
     return <HeaderFallback language={props.language} />;
   }
   return <HeaderInner {...props} />;


### PR DESCRIPTION
## Summary
- `ClientLayout` は `!session || pathname === \"/login\"` で `SidebarProvider` をスキップするのに対し、`Header` は `!props.session` のみで分岐していた不整合を修正
- セッションが残ったまま `/login` に居る過渡状態で `HeaderInner` が `useSidebar` を呼び `useSidebar must be used within a SidebarProvider.` でクラッシュする問題を解消
- `Header` 関数に `usePathname` 判定を追加し、`ClientLayout` の分岐条件と対称化

Closes #29

## Test plan
- [ ] ログイン状態で `/admin` から `/login` に手動遷移し、過渡状態で Runtime Error が出ないこと
- [ ] 通常のログイン/ログアウトフローで Header が正しく切り替わること
- [ ] `HeaderFallback` 側に切り替わったときも言語表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)