### PR TITLE
fix(ai-playground): SSE エラー伝播と endpoint フォールバック (Issue #35)

### DIFF
--- a/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
+++ b/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
@@ -217,29 +217,32 @@ export function AiPlaygroundPage({ language }: { language: "en" | "ja" }) {
           const chunk = decoder.decode(value, { stream: true });
           for (const line of chunk.split("\n")) {
             if (!line.trim() || line === "data: [DONE]" || !line.startsWith("data: ")) continue;
+            let data: { error?: string; content?: string };
             try {
-              const data = JSON.parse(line.slice(6));
-              if (data.error) throw new Error(data.error);
-              if (data.content) {
-                content += data.content;
-                setStreamingContent(content);
-                const currentTime = Date.now();
-                const outputTokens = estimateTokenCount(content);
-                const timeSinceLastUpdate = currentTime - lastTokenTimeRef.current;
-                if (timeSinceLastUpdate > 100) {
-                  const tokensSinceLastUpdate = outputTokens - lastTokenCountRef.current;
-                  lastTokenCountRef.current = outputTokens;
-                  lastTokenTimeRef.current = currentTime;
-                  setMetrics((prev) => ({
-                    ...prev,
-                    outputTokens,
-                    contextUsagePercent: ((prev.inputTokens + outputTokens) / prev.contextWindowSize) * 100,
-                    tokensPerSecond: (tokensSinceLastUpdate / timeSinceLastUpdate) * 1000,
-                    totalTimeMs: currentTime - generationStartTimeRef.current,
-                  }));
-                }
+              data = JSON.parse(line.slice(6));
+            } catch {
+              continue;
+            }
+            if (data.error) throw new Error(data.error);
+            if (data.content) {
+              content += data.content;
+              setStreamingContent(content);
+              const currentTime = Date.now();
+              const outputTokens = estimateTokenCount(content);
+              const timeSinceLastUpdate = currentTime - lastTokenTimeRef.current;
+              if (timeSinceLastUpdate > 100) {
+                const tokensSinceLastUpdate = outputTokens - lastTokenCountRef.current;
+                lastTokenCountRef.current = outputTokens;
+                lastTokenTimeRef.current = currentTime;
+                setMetrics((prev) => ({
+                  ...prev,
+                  outputTokens,
+                  contextUsagePercent: ((prev.inputTokens + outputTokens) / prev.contextWindowSize) * 100,
+                  tokensPerSecond: (tokensSinceLastUpdate / timeSinceLastUpdate) * 1000,
+                  totalTimeMs: currentTime - generationStartTimeRef.current,
+                }));
               }
-            } catch { /* skip */ }
+            }
           }
         }
 

--- a/apps/web/app/api/ai-playground/settings/route.ts
+++ b/apps/web/app/api/ai-playground/settings/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -9,6 +9,59 @@ const SETTINGS_KEYS = {
   RAG_CONFIG: "ai_playground_rag_config",
 } as const;
 
+const GLOBAL_AI_KEYS = [
+  "ai_local_endpoint",
+  "ai_local_provider",
+  "ai_local_model",
+] as const;
+
+function deriveOpenAIBase(endpoint: string): string {
+  const trimmed = endpoint.trim().replace(/\/+$/, "");
+  try {
+    return `${new URL(trimmed).origin}/v1`;
+  } catch {
+    return trimmed;
+  }
+}
+
+function mapLocalProvider(provider: string | undefined): string | undefined {
+  if (!provider) return undefined;
+  if (provider === "llama.cpp") return "llama-cpp";
+  if (
+    provider === "lm-studio" ||
+    provider === "ollama" ||
+    provider === "llama-cpp"
+  )
+    return provider;
+  return undefined;
+}
+
+function applyPlaygroundLlmFallback(
+  current: unknown,
+  globals: Record<string, string | undefined>,
+): unknown {
+  const cfg: Record<string, unknown> =
+    current && typeof current === "object"
+      ? { ...(current as Record<string, unknown>) }
+      : {};
+  const endpoint = globals.ai_local_endpoint;
+  const provider = mapLocalProvider(globals.ai_local_provider);
+  const model = globals.ai_local_model;
+
+  const hasProvider =
+    typeof cfg.provider === "string" && (cfg.provider as string).length > 0;
+  const hasBaseUrl =
+    typeof cfg.baseUrl === "string" && (cfg.baseUrl as string).length > 0;
+  const hasModel =
+    typeof cfg.model === "string" && (cfg.model as string).length > 0;
+
+  if (!hasProvider && provider) cfg.provider = provider;
+  if (!hasBaseUrl && endpoint) cfg.baseUrl = deriveOpenAIBase(endpoint);
+  if (!hasModel && model) cfg.model = model;
+
+  return cfg.provider || cfg.baseUrl || cfg.model ? cfg : current;
+}
+
 export async function GET() {
   try {
     const session = await auth();
@@ -18,18 +71,34 @@ export async function GET() {
 
     const settings = await prisma.systemSetting.findMany({
       where: {
-        key: { in: [...Object.values(SETTINGS_KEYS), "ai_enabled"] },
+        key: {
+          in: [
+            ...Object.values(SETTINGS_KEYS),
+            "ai_enabled",
+            ...GLOBAL_AI_KEYS,
+          ],
+        },
       },
     });
 
     const result: Record<string, unknown> = {};
+    const globals: Record<string, string | undefined> = {};
     for (const setting of settings) {
+      if ((GLOBAL_AI_KEYS as readonly string[]).includes(setting.key)) {
+        globals[setting.key] = setting.value;
+        continue;
+      }
       try {
         result[setting.key] = JSON.parse(setting.value);
       } catch {
         result[setting.key] = setting.value;
       }
     }
+
+    result[SETTINGS_KEYS.LLM_CONFIG] = applyPlaygroundLlmFallback(
+      result[SETTINGS_KEYS.LLM_CONFIG],
+      globals,
+    );
 
     return NextResponse.json(result);
   } catch (error) {


### PR DESCRIPTION
## Summary
- **Bug 1**: SSE パース catch が `data.error` の throw も握り潰していたのを分離し、サーバから返るストリーム内エラーを画面に表示する
- **Bug 2**: `ai_playground_llm_config` 未設定時は全般 AI 設定 (`ai_local_endpoint`/`ai_local_provider`/`ai_local_model`) から導出して接続するフォールバックを追加

Closes #35

## Test plan
- [ ] LLM 未起動でチャット送信すると、画面にエラーメッセージが表示される（旧: 無音）
- [ ] `ai_playground_llm_config` 未保存でも `ai_local_endpoint` のみで Playground が動作
- [ ] `ai_local_endpoint` が `http://host:8080/v1` でも `http://host:8080/v1/chat/completions` でも動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)