### PR TITLE
fix(ai-settings): localEndpoint / baseUrl にスキーム必須バリデーションを追加 (Issue #38)

### DIFF
--- a/apps/web/__tests__/lib/utils/url-validation.test.ts
+++ b/apps/web/__tests__/lib/utils/url-validation.test.ts
@@ -1,0 +1,81 @@
+import {
+  urlValidationMessage,
+  validateHttpUrl,
+} from "@/lib/utils/url-validation";
+
+describe("validateHttpUrl", () => {
+  it("rejects empty string", () => {
+    expect(validateHttpUrl("")).toEqual({ ok: false, reason: "empty" });
+    expect(validateHttpUrl("   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects missing scheme", () => {
+    expect(validateHttpUrl("localhost:8080")).toEqual({
+      ok: false,
+      reason: "missing-scheme",
+    });
+    expect(validateHttpUrl("example.com")).toEqual({
+      ok: false,
+      reason: "missing-scheme",
+    });
+    expect(validateHttpUrl("ftp://example.com")).toEqual({
+      ok: false,
+      reason: "missing-scheme",
+    });
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(validateHttpUrl("http://[unclosed")).toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+
+  it("accepts valid http URLs", () => {
+    expect(validateHttpUrl("http://localhost:8080")).toEqual({
+      ok: true,
+      url: "http://localhost:8080",
+    });
+    expect(validateHttpUrl("http://localhost:8080/v1")).toEqual({
+      ok: true,
+      url: "http://localhost:8080/v1",
+    });
+    expect(
+      validateHttpUrl("http://localhost:8080/v1/chat/completions"),
+    ).toEqual({ ok: true, url: "http://localhost:8080/v1/chat/completions" });
+  });
+
+  it("accepts valid https URLs", () => {
+    expect(validateHttpUrl("https://api.example.com/v1")).toEqual({
+      ok: true,
+      url: "https://api.example.com/v1",
+    });
+  });
+
+  it("trims whitespace and trailing slashes", () => {
+    expect(validateHttpUrl("  http://host:8080/v1/  ")).toEqual({
+      ok: true,
+      url: "http://host:8080/v1",
+    });
+    expect(validateHttpUrl("http://host:8080///")).toEqual({
+      ok: true,
+      url: "http://host:8080",
+    });
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(validateHttpUrl("HTTP://localhost:8080")).toEqual({
+      ok: true,
+      url: "HTTP://localhost:8080",
+    });
+  });
+});
+
+describe("urlValidationMessage", () => {
+  it("returns localized messages", () => {
+    expect(urlValidationMessage("empty", "ja")).toBe("URL を入力してください");
+    expect(urlValidationMessage("empty", "en")).toBe("URL is required");
+    expect(urlValidationMessage("missing-scheme", "ja")).toContain("http://");
+    expect(urlValidationMessage("invalid", "en")).toBe("URL format is invalid");
+  });
+});

--- a/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
+++ b/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
@@ -1,6 +1,18 @@
 "use client";
 
+import type {
+  RAGConfig,
+  SearchConfig,
+  SystemPrompts,
+} from "@lionframe/addon-ai-playground";
+import { DEFAULT_SYSTEM_PROMPTS } from "@lionframe/addon-ai-playground/src/prompts";
+import {
+  DEFAULT_RAG_CONFIG,
+  DEFAULT_SEARCH_CONFIG,
+} from "@lionframe/addon-ai-playground/src/types";
 import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -8,12 +20,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -21,9 +29,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { DEFAULT_SYSTEM_PROMPTS } from "@lionframe/addon-ai-playground/src/prompts";
-import type { SystemPrompts, SearchConfig, RAGConfig } from "@lionframe/addon-ai-playground";
-import { DEFAULT_SEARCH_CONFIG, DEFAULT_RAG_CONFIG } from "@lionframe/addon-ai-playground/src/types";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  type UrlValidationError,
+  urlValidationMessage,
+  validateHttpUrl,
+} from "@/lib/utils/url-validation";
 import { AiSettingsSkeleton } from "./AiSettingsSkeleton";
 import type { TabId } from "./types";
 
@@ -42,7 +54,13 @@ interface LocalLLMDefaults {
   [key: string]: { endpoint: string; model: string };
 }
 
-const EMPTY_PROMPTS: SystemPrompts = { common: "", explain: "", idea: "", search: "", rag: "" };
+const EMPTY_PROMPTS: SystemPrompts = {
+  common: "",
+  explain: "",
+  idea: "",
+  search: "",
+  rag: "",
+};
 
 const PROMPT_KEYS = ["common", "explain", "idea", "search", "rag"] as const;
 
@@ -77,7 +95,13 @@ const translations = {
     ragCategory: "Category",
     promptTitle: "Prompt Settings",
     promptDescription: "Customize system prompts for each AI Playground mode",
-    promptLabels: { common: "Common Prompt", explain: "Explain Mode", idea: "Idea Mode", search: "Search Mode", rag: "RAG Mode" },
+    promptLabels: {
+      common: "Common Prompt",
+      explain: "Explain Mode",
+      idea: "Idea Mode",
+      search: "Search Mode",
+      rag: "RAG Mode",
+    },
     resetDefaults: "Reset to Defaults",
     defaultPrompt: "Default",
     customPrompt: "Custom",
@@ -116,7 +140,13 @@ const translations = {
     ragCategory: "カテゴリ",
     promptTitle: "プロンプト設定",
     promptDescription: "AI体験の各モードのシステムプロンプトをカスタマイズ",
-    promptLabels: { common: "共通プロンプト", explain: "やさしく説明モード", idea: "企画アイデアモード", search: "検索して要約モード", rag: "ナレッジ検索モード" },
+    promptLabels: {
+      common: "共通プロンプト",
+      explain: "やさしく説明モード",
+      idea: "企画アイデアモード",
+      search: "検索して要約モード",
+      rag: "ナレッジ検索モード",
+    },
     resetDefaults: "デフォルトに戻す",
     defaultPrompt: "デフォルト",
     customPrompt: "カスタム",
@@ -127,21 +157,48 @@ const translations = {
   },
 };
 
-export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab: TabId }) {
+export function AiSettingsClient({
+  language,
+  tab,
+}: {
+  language: "en" | "ja";
+  tab: TabId;
+}) {
   const t = translations[language];
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
   const [aiConfig, setAiConfig] = useState<AIConfig | null>(null);
-  const [localLLMDefaults, setLocalLLMDefaults] = useState<LocalLLMDefaults | null>(null);
+  const [localLLMDefaults, setLocalLLMDefaults] =
+    useState<LocalLLMDefaults | null>(null);
   const [aiApiKeyInput, setAiApiKeyInput] = useState("");
-  const [generalTestResult, setGeneralTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [generalTestResult, setGeneralTestResult] = useState<{
+    success: boolean;
+    message: string;
+  } | null>(null);
   const [generalTesting, setGeneralTesting] = useState(false);
 
-  const [searchConfig, setSearchConfig] = useState<SearchConfig>(DEFAULT_SEARCH_CONFIG);
+  const [searchConfig, setSearchConfig] = useState<SearchConfig>(
+    DEFAULT_SEARCH_CONFIG,
+  );
   const [ragConfig, setRagConfig] = useState<RAGConfig>(DEFAULT_RAG_CONFIG);
-  const [systemPrompts, setSystemPrompts] = useState<SystemPrompts | null>(null);
+  const [systemPrompts, setSystemPrompts] = useState<SystemPrompts | null>(
+    null,
+  );
+
+  const [localEndpointInput, setLocalEndpointInput] = useState("");
+  const [localEndpointError, setLocalEndpointError] =
+    useState<UrlValidationError | null>(null);
+  const [ragBaseUrlError, setRagBaseUrlError] =
+    useState<UrlValidationError | null>(null);
+
+  useEffect(() => {
+    if (aiConfig?.localEndpoint !== undefined) {
+      setLocalEndpointInput(aiConfig.localEndpoint);
+      setLocalEndpointError(null);
+    }
+  }, [aiConfig?.localEndpoint]);
 
   useEffect(() => {
     const fetches: Promise<Record<string, unknown>>[] = [
@@ -153,49 +210,138 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
     Promise.all(fetches)
       .then(([aiData, pgData]) => {
         if (aiData.config) setAiConfig(aiData.config as AIConfig);
-        if (aiData.localLLMDefaults) setLocalLLMDefaults(aiData.localLLMDefaults as LocalLLMDefaults);
+        if (aiData.localLLMDefaults)
+          setLocalLLMDefaults(aiData.localLLMDefaults as LocalLLMDefaults);
         if (pgData) {
-          if (pgData.ai_playground_search_config) setSearchConfig(pgData.ai_playground_search_config as SearchConfig);
-          if (pgData.ai_playground_rag_config) setRagConfig(pgData.ai_playground_rag_config as RAGConfig);
-          if (pgData.ai_playground_system_prompts) setSystemPrompts(pgData.ai_playground_system_prompts as SystemPrompts);
+          if (pgData.ai_playground_search_config)
+            setSearchConfig(pgData.ai_playground_search_config as SearchConfig);
+          if (pgData.ai_playground_rag_config)
+            setRagConfig(pgData.ai_playground_rag_config as RAGConfig);
+          if (pgData.ai_playground_system_prompts)
+            setSystemPrompts(
+              pgData.ai_playground_system_prompts as SystemPrompts,
+            );
         }
       })
       .finally(() => setLoading(false));
   }, [tab]);
 
-  const handleUpdateAiConfig = useCallback(async (updates: Partial<AIConfig & { apiKey?: string }>) => {
-    setSaving(true);
-    try {
-      const res = await fetch("/api/admin/ai", { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(updates) });
-      if (res.ok) { const data = await res.json(); setAiConfig(data.config); setAiApiKeyInput(""); setGeneralTestResult(null); setSaved(true); setTimeout(() => setSaved(false), 2000); }
-    } finally { setSaving(false); }
-  }, []);
+  const handleUpdateAiConfig = useCallback(
+    async (updates: Partial<AIConfig & { apiKey?: string }>) => {
+      setSaving(true);
+      try {
+        const res = await fetch("/api/admin/ai", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setAiConfig(data.config);
+          setAiApiKeyInput("");
+          setGeneralTestResult(null);
+          setSaved(true);
+          setTimeout(() => setSaved(false), 2000);
+        }
+      } finally {
+        setSaving(false);
+      }
+    },
+    [],
+  );
 
   const handleTestGeneral = useCallback(async () => {
-    setGeneralTesting(true); setGeneralTestResult(null);
+    setGeneralTesting(true);
+    setGeneralTestResult(null);
     try {
-      const res = await fetch("/api/admin/ai", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "test-connection" }) });
+      const res = await fetch("/api/admin/ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "test-connection" }),
+      });
       const data = await res.json();
-      setGeneralTestResult({ success: data.success, message: data.success ? (language === "ja" ? "接続成功" : "Connected") : (data.error || t.connectionFailed) });
-    } catch { setGeneralTestResult({ success: false, message: t.connectionFailed }); }
-    finally { setGeneralTesting(false); }
+      setGeneralTestResult({
+        success: data.success,
+        message: data.success
+          ? language === "ja"
+            ? "接続成功"
+            : "Connected"
+          : data.error || t.connectionFailed,
+      });
+    } catch {
+      setGeneralTestResult({ success: false, message: t.connectionFailed });
+    } finally {
+      setGeneralTesting(false);
+    }
   }, [language, t]);
 
   const handleSavePlayground = useCallback(async () => {
-    setSaving(true); setSaved(false);
+    const ragResult = validateHttpUrl(ragConfig.baseUrl);
+    if (!ragResult.ok) {
+      setRagBaseUrlError(ragResult.reason);
+      return;
+    }
+    setRagBaseUrlError(null);
+    setSaving(true);
+    setSaved(false);
     try {
-      const body: Record<string, unknown> = { ai_playground_search_config: searchConfig, ai_playground_rag_config: ragConfig };
+      const body: Record<string, unknown> = {
+        ai_playground_search_config: searchConfig,
+        ai_playground_rag_config: { ...ragConfig, baseUrl: ragResult.url },
+      };
       if (systemPrompts) body.ai_playground_system_prompts = systemPrompts;
-      await fetch("/api/ai-playground/settings", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
-      setSaved(true); setTimeout(() => setSaved(false), 2000);
-    } finally { setSaving(false); }
+      await fetch("/api/ai-playground/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setSaving(false);
+    }
   }, [searchConfig, ragConfig, systemPrompts]);
+
+  const handleLocalEndpointChange = useCallback(
+    (value: string) => {
+      setLocalEndpointInput(value);
+      if (localEndpointError) {
+        const result = validateHttpUrl(value);
+        if (result.ok) setLocalEndpointError(null);
+      }
+    },
+    [localEndpointError],
+  );
+
+  const handleLocalEndpointBlur = useCallback(() => {
+    const result = validateHttpUrl(localEndpointInput);
+    if (!result.ok) {
+      setLocalEndpointError(result.reason);
+      return;
+    }
+    setLocalEndpointError(null);
+    if (result.url !== aiConfig?.localEndpoint) {
+      handleUpdateAiConfig({ localEndpoint: result.url });
+    }
+  }, [localEndpointInput, aiConfig?.localEndpoint, handleUpdateAiConfig]);
+
+  const handleRagBaseUrlChange = useCallback(
+    (value: string) => {
+      setRagConfig((prev) => ({ ...prev, baseUrl: value }));
+      if (ragBaseUrlError) {
+        const result = validateHttpUrl(value);
+        if (result.ok) setRagBaseUrlError(null);
+      }
+    },
+    [ragBaseUrlError],
+  );
 
   if (loading) return <AiSettingsSkeleton tab={tab} />;
 
   return (
-    <div className={`${tab === "playground" ? "max-w-6xl" : "max-w-4xl"} mx-auto mt-8 space-y-6`}>
-
+    <div
+      className={`${tab === "playground" ? "max-w-6xl" : "max-w-4xl"} mx-auto mt-8 space-y-6`}
+    >
       {tab === "general" && aiConfig && (
         <Card>
           <CardHeader>
@@ -207,18 +353,38 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
               <div className="flex items-center justify-between">
                 <div>
                   <h3 className="font-medium text-foreground">{t.enableAi}</h3>
-                  <p className="text-sm text-muted-foreground mt-1">{t.enableAiDesc}</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {t.enableAiDesc}
+                  </p>
                 </div>
-                <Switch checked={aiConfig.enabled} onCheckedChange={(checked) => handleUpdateAiConfig({ enabled: checked })} disabled={saving} />
+                <Switch
+                  checked={aiConfig.enabled}
+                  onCheckedChange={(checked) =>
+                    handleUpdateAiConfig({ enabled: checked })
+                  }
+                  disabled={saving}
+                />
               </div>
             </div>
 
             <div className="space-y-2">
               <Label>{t.aiProvider}</Label>
-              <Select value={aiConfig.provider} onValueChange={(value) => handleUpdateAiConfig({ provider: value as "openai" | "anthropic" | "local" })} disabled={saving}>
-                <SelectTrigger className="w-full md:w-[300px]"><SelectValue /></SelectTrigger>
+              <Select
+                value={aiConfig.provider}
+                onValueChange={(value) =>
+                  handleUpdateAiConfig({
+                    provider: value as "openai" | "anthropic" | "local",
+                  })
+                }
+                disabled={saving}
+              >
+                <SelectTrigger className="w-full md:w-[300px]">
+                  <SelectValue />
+                </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="local">{t.localLlm} ({t.recommended})</SelectItem>
+                  <SelectItem value="local">
+                    {t.localLlm} ({t.recommended})
+                  </SelectItem>
                   <SelectItem value="openai">OpenAI</SelectItem>
                   <SelectItem value="anthropic">Anthropic (Claude)</SelectItem>
                 </SelectContent>
@@ -229,10 +395,26 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
               <>
                 <div className="space-y-2">
                   <Label>{t.localServer}</Label>
-                  <Select value={aiConfig.localProvider} onValueChange={(value) => { const p = value as "llama.cpp" | "lm-studio" | "ollama"; const d = localLLMDefaults?.[p]; handleUpdateAiConfig({ localProvider: p, localEndpoint: d?.endpoint || "", localModel: d?.model || "" }); }} disabled={saving}>
-                    <SelectTrigger className="w-full md:w-[300px]"><SelectValue /></SelectTrigger>
+                  <Select
+                    value={aiConfig.localProvider}
+                    onValueChange={(value) => {
+                      const p = value as "llama.cpp" | "lm-studio" | "ollama";
+                      const d = localLLMDefaults?.[p];
+                      handleUpdateAiConfig({
+                        localProvider: p,
+                        localEndpoint: d?.endpoint || "",
+                        localModel: d?.model || "",
+                      });
+                    }}
+                    disabled={saving}
+                  >
+                    <SelectTrigger className="w-full md:w-[300px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="llama.cpp">llama.cpp ({t.default})</SelectItem>
+                      <SelectItem value="llama.cpp">
+                        llama.cpp ({t.default})
+                      </SelectItem>
                       <SelectItem value="lm-studio">LM Studio</SelectItem>
                       <SelectItem value="ollama">Ollama</SelectItem>
                     </SelectContent>
@@ -240,11 +422,29 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
                 </div>
                 <div className="space-y-2">
                   <Label>{t.endpointUrl}</Label>
-                  <Input value={aiConfig.localEndpoint} onChange={(e) => handleUpdateAiConfig({ localEndpoint: e.target.value })} className="font-mono" disabled={saving} />
+                  <Input
+                    value={localEndpointInput}
+                    onChange={(e) => handleLocalEndpointChange(e.target.value)}
+                    onBlur={handleLocalEndpointBlur}
+                    className={`font-mono ${localEndpointError ? "border-red-500 focus-visible:ring-red-500" : ""}`}
+                    disabled={saving}
+                    aria-invalid={localEndpointError !== null}
+                  />
+                  {localEndpointError && (
+                    <p className="text-sm text-red-600 dark:text-red-400">
+                      {urlValidationMessage(localEndpointError, language)}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label>{t.modelName}</Label>
-                  <Input value={aiConfig.localModel} onChange={(e) => handleUpdateAiConfig({ localModel: e.target.value })} disabled={saving} />
+                  <Input
+                    value={aiConfig.localModel}
+                    onChange={(e) =>
+                      handleUpdateAiConfig({ localModel: e.target.value })
+                    }
+                    disabled={saving}
+                  />
                 </div>
               </>
             )}
@@ -253,11 +453,35 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
               <>
                 <div className="space-y-2">
                   <Label>{t.aiModel}</Label>
-                  <Select value={aiConfig.model} onValueChange={(value) => handleUpdateAiConfig({ model: value })} disabled={saving}>
-                    <SelectTrigger className="w-full md:w-[300px]"><SelectValue /></SelectTrigger>
+                  <Select
+                    value={aiConfig.model}
+                    onValueChange={(value) =>
+                      handleUpdateAiConfig({ model: value })
+                    }
+                    disabled={saving}
+                  >
+                    <SelectTrigger className="w-full md:w-[300px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {aiConfig.provider === "openai" && <><SelectItem value="gpt-4o-mini">GPT-4o mini ({t.recommended})</SelectItem><SelectItem value="gpt-4o">GPT-4o</SelectItem></>}
-                      {aiConfig.provider === "anthropic" && <><SelectItem value="claude-3-haiku-20240307">Claude 3 Haiku ({t.recommended})</SelectItem><SelectItem value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet</SelectItem></>}
+                      {aiConfig.provider === "openai" && (
+                        <>
+                          <SelectItem value="gpt-4o-mini">
+                            GPT-4o mini ({t.recommended})
+                          </SelectItem>
+                          <SelectItem value="gpt-4o">GPT-4o</SelectItem>
+                        </>
+                      )}
+                      {aiConfig.provider === "anthropic" && (
+                        <>
+                          <SelectItem value="claude-3-haiku-20240307">
+                            Claude 3 Haiku ({t.recommended})
+                          </SelectItem>
+                          <SelectItem value="claude-3-5-sonnet-20241022">
+                            Claude 3.5 Sonnet
+                          </SelectItem>
+                        </>
+                      )}
                     </SelectContent>
                   </Select>
                 </div>
@@ -265,13 +489,37 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
                   <Label>{t.apiKeyLabel}</Label>
                   {aiConfig.hasApiKey ? (
                     <div className="flex items-center gap-4">
-                      <Input value={aiConfig.apiKey || ""} disabled className="flex-1 font-mono" />
-                      <Button variant="outline" onClick={() => handleUpdateAiConfig({ apiKey: "" })} disabled={saving}>{t.removeKey}</Button>
+                      <Input
+                        value={aiConfig.apiKey || ""}
+                        disabled
+                        className="flex-1 font-mono"
+                      />
+                      <Button
+                        variant="outline"
+                        onClick={() => handleUpdateAiConfig({ apiKey: "" })}
+                        disabled={saving}
+                      >
+                        {t.removeKey}
+                      </Button>
                     </div>
                   ) : (
                     <div className="flex items-center gap-4">
-                      <Input type="password" value={aiApiKeyInput} onChange={(e) => setAiApiKeyInput(e.target.value)} placeholder="sk-..." className="flex-1" />
-                      <Button variant="outline" onClick={() => handleUpdateAiConfig({ apiKey: aiApiKeyInput })} disabled={saving || !aiApiKeyInput}>{t.setKey}</Button>
+                      <Input
+                        type="password"
+                        value={aiApiKeyInput}
+                        onChange={(e) => setAiApiKeyInput(e.target.value)}
+                        placeholder="sk-..."
+                        className="flex-1"
+                      />
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          handleUpdateAiConfig({ apiKey: aiApiKeyInput })
+                        }
+                        disabled={saving || !aiApiKeyInput}
+                      >
+                        {t.setKey}
+                      </Button>
                     </div>
                   )}
                 </div>
@@ -279,17 +527,35 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
             )}
 
             <div className="flex items-center gap-3">
-              <Button variant="outline" onClick={handleTestGeneral} disabled={generalTesting || saving}>{generalTesting ? t.testing : t.testConnection}</Button>
+              <Button
+                variant="outline"
+                onClick={handleTestGeneral}
+                disabled={generalTesting || saving}
+              >
+                {generalTesting ? t.testing : t.testConnection}
+              </Button>
               {generalTestResult && (
-                <Badge className={generalTestResult.success ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"}>
+                <Badge
+                  className={
+                    generalTestResult.success
+                      ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                      : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
+                  }
+                >
                   {generalTestResult.message}
                 </Badge>
               )}
             </div>
 
-            <div className={`flex items-center gap-2 p-4 rounded-lg ${aiConfig.enabled ? "bg-green-50 dark:bg-green-950/30" : "bg-muted"}`}>
-              <span className={`w-2 h-2 rounded-full ${aiConfig.enabled ? "bg-green-500" : "bg-muted-foreground"}`} />
-              <span className="text-sm">{aiConfig.enabled ? t.aiAvailable : t.aiDisabled}</span>
+            <div
+              className={`flex items-center gap-2 p-4 rounded-lg ${aiConfig.enabled ? "bg-green-50 dark:bg-green-950/30" : "bg-muted"}`}
+            >
+              <span
+                className={`w-2 h-2 rounded-full ${aiConfig.enabled ? "bg-green-500" : "bg-muted-foreground"}`}
+              />
+              <span className="text-sm">
+                {aiConfig.enabled ? t.aiAvailable : t.aiDisabled}
+              </span>
             </div>
           </CardContent>
         </Card>
@@ -298,32 +564,114 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
       {tab === "playground" && (
         <>
           <Card>
-            <CardHeader><CardTitle>{t.searchSettings}</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>{t.searchSettings}</CardTitle>
+            </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
                 <Label>{t.searchProvider}</Label>
                 <div className="flex gap-2">
-                  <Button variant={searchConfig.provider === "duckduckgo" ? "default" : "outline"} size="sm" onClick={() => setSearchConfig((prev) => ({ ...prev, provider: "duckduckgo" }))}>DuckDuckGo</Button>
-                  <Button variant={searchConfig.provider === "brave" ? "default" : "outline"} size="sm" onClick={() => setSearchConfig((prev) => ({ ...prev, provider: "brave" }))}>Brave Search</Button>
+                  <Button
+                    variant={
+                      searchConfig.provider === "duckduckgo"
+                        ? "default"
+                        : "outline"
+                    }
+                    size="sm"
+                    onClick={() =>
+                      setSearchConfig((prev) => ({
+                        ...prev,
+                        provider: "duckduckgo",
+                      }))
+                    }
+                  >
+                    DuckDuckGo
+                  </Button>
+                  <Button
+                    variant={
+                      searchConfig.provider === "brave" ? "default" : "outline"
+                    }
+                    size="sm"
+                    onClick={() =>
+                      setSearchConfig((prev) => ({
+                        ...prev,
+                        provider: "brave",
+                      }))
+                    }
+                  >
+                    Brave Search
+                  </Button>
                 </div>
               </div>
               {searchConfig.provider === "brave" && (
-                <div className="space-y-2"><Label>{t.braveApiKey}</Label><Input type="password" value={searchConfig.braveApiKey || ""} onChange={(e) => setSearchConfig((prev) => ({ ...prev, braveApiKey: e.target.value }))} placeholder={t.braveApiKeyPlaceholder} /></div>
+                <div className="space-y-2">
+                  <Label>{t.braveApiKey}</Label>
+                  <Input
+                    type="password"
+                    value={searchConfig.braveApiKey || ""}
+                    onChange={(e) =>
+                      setSearchConfig((prev) => ({
+                        ...prev,
+                        braveApiKey: e.target.value,
+                      }))
+                    }
+                    placeholder={t.braveApiKeyPlaceholder}
+                  />
+                </div>
               )}
             </CardContent>
           </Card>
           <Card>
-            <CardHeader><CardTitle>{t.ragSettings}</CardTitle></CardHeader>
+            <CardHeader>
+              <CardTitle>{t.ragSettings}</CardTitle>
+            </CardHeader>
             <CardContent className="space-y-4">
-              <div className="space-y-2"><Label>{t.ragBaseUrl}</Label><Input value={ragConfig.baseUrl} onChange={(e) => setRagConfig((prev) => ({ ...prev, baseUrl: e.target.value }))} /></div>
-              <div className="space-y-2"><Label>{t.ragCategory}</Label><Input value={ragConfig.category} onChange={(e) => setRagConfig((prev) => ({ ...prev, category: e.target.value }))} /></div>
+              <div className="space-y-2">
+                <Label>{t.ragBaseUrl}</Label>
+                <Input
+                  value={ragConfig.baseUrl}
+                  onChange={(e) => handleRagBaseUrlChange(e.target.value)}
+                  className={
+                    ragBaseUrlError
+                      ? "border-red-500 focus-visible:ring-red-500"
+                      : ""
+                  }
+                  aria-invalid={ragBaseUrlError !== null}
+                />
+                {ragBaseUrlError && (
+                  <p className="text-sm text-red-600 dark:text-red-400">
+                    {urlValidationMessage(ragBaseUrlError, language)}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label>{t.ragCategory}</Label>
+                <Input
+                  value={ragConfig.category}
+                  onChange={(e) =>
+                    setRagConfig((prev) => ({
+                      ...prev,
+                      category: e.target.value,
+                    }))
+                  }
+                />
+              </div>
             </CardContent>
           </Card>
           <Card>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <div><CardTitle>{t.promptTitle}</CardTitle><CardDescription>{t.promptDescription}</CardDescription></div>
-                <Button variant="outline" size="sm" onClick={() => setSystemPrompts(null)}>{t.resetDefaults}</Button>
+                <div>
+                  <CardTitle>{t.promptTitle}</CardTitle>
+                  <CardDescription>{t.promptDescription}</CardDescription>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSystemPrompts(null)}
+                >
+                  {t.resetDefaults}
+                </Button>
               </div>
             </CardHeader>
             <CardContent className="space-y-8">
@@ -332,7 +680,9 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
                   <Label>{t.promptLabels[key]}</Label>
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-1">
-                      <span className="text-xs text-muted-foreground">{t.defaultPrompt}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {t.defaultPrompt}
+                      </span>
                       <Textarea
                         className="min-h-[120px] bg-muted text-muted-foreground font-mono"
                         value={DEFAULT_SYSTEM_PROMPTS[key]}
@@ -340,11 +690,19 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
                       />
                     </div>
                     <div className="space-y-1">
-                      <span className="text-xs text-muted-foreground">{t.customPrompt}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {t.customPrompt}
+                      </span>
                       <Textarea
                         className="min-h-[120px] font-mono"
                         value={systemPrompts?.[key] || ""}
-                        onChange={(e) => setSystemPrompts((prev) => ({ ...EMPTY_PROMPTS, ...prev, [key]: e.target.value }))}
+                        onChange={(e) =>
+                          setSystemPrompts((prev) => ({
+                            ...EMPTY_PROMPTS,
+                            ...prev,
+                            [key]: e.target.value,
+                          }))
+                        }
                         placeholder={t.promptPlaceholder}
                       />
                     </div>
@@ -353,7 +711,11 @@ export function AiSettingsClient({ language, tab }: { language: "en" | "ja"; tab
               ))}
             </CardContent>
           </Card>
-          <div className="flex justify-end"><Button onClick={handleSavePlayground} disabled={saving}>{saving ? t.saving : saved ? t.saved : t.save}</Button></div>
+          <div className="flex justify-end">
+            <Button onClick={handleSavePlayground} disabled={saving}>
+              {saving ? t.saving : saved ? t.saved : t.save}
+            </Button>
+          </div>
         </>
       )}
     </div>

--- a/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
+++ b/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
@@ -192,6 +192,7 @@ export function AiSettingsClient({
     useState<UrlValidationError | null>(null);
   const [ragBaseUrlError, setRagBaseUrlError] =
     useState<UrlValidationError | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (aiConfig?.localEndpoint !== undefined) {
@@ -276,31 +277,49 @@ export function AiSettingsClient({
   }, [language, t]);
 
   const handleSavePlayground = useCallback(async () => {
-    const ragResult = validateHttpUrl(ragConfig.baseUrl);
-    if (!ragResult.ok) {
-      setRagBaseUrlError(ragResult.reason);
-      return;
+    const trimmedRagUrl = ragConfig.baseUrl.trim();
+    let normalizedRagBaseUrl = ragConfig.baseUrl;
+    if (trimmedRagUrl !== "") {
+      const ragResult = validateHttpUrl(ragConfig.baseUrl);
+      if (!ragResult.ok) {
+        setRagBaseUrlError(ragResult.reason);
+        return;
+      }
+      normalizedRagBaseUrl = ragResult.url;
     }
     setRagBaseUrlError(null);
+    setSaveError(null);
     setSaving(true);
     setSaved(false);
     try {
       const body: Record<string, unknown> = {
         ai_playground_search_config: searchConfig,
-        ai_playground_rag_config: { ...ragConfig, baseUrl: ragResult.url },
+        ai_playground_rag_config: {
+          ...ragConfig,
+          baseUrl: normalizedRagBaseUrl,
+        },
       };
       if (systemPrompts) body.ai_playground_system_prompts = systemPrompts;
-      await fetch("/api/ai-playground/settings", {
+      const res = await fetch("/api/ai-playground/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const message =
+          data.errorJa ||
+          data.error ||
+          (language === "ja" ? "保存に失敗しました" : "Failed to save");
+        setSaveError(message);
+        return;
+      }
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } finally {
       setSaving(false);
     }
-  }, [searchConfig, ragConfig, systemPrompts]);
+  }, [searchConfig, ragConfig, systemPrompts, language]);
 
   const handleLocalEndpointChange = useCallback(
     (value: string) => {
@@ -631,11 +650,11 @@ export function AiSettingsClient({
                 <Input
                   value={ragConfig.baseUrl}
                   onChange={(e) => handleRagBaseUrlChange(e.target.value)}
-                  className={
+                  className={`font-mono ${
                     ragBaseUrlError
                       ? "border-red-500 focus-visible:ring-red-500"
                       : ""
-                  }
+                  }`}
                   aria-invalid={ragBaseUrlError !== null}
                 />
                 {ragBaseUrlError && (
@@ -711,7 +730,12 @@ export function AiSettingsClient({
               ))}
             </CardContent>
           </Card>
-          <div className="flex justify-end">
+          <div className="flex items-center justify-end gap-3">
+            {saveError && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {saveError}
+              </p>
+            )}
             <Button onClick={handleSavePlayground} disabled={saving}>
               {saving ? t.saving : saved ? t.saved : t.save}
             </Button>

--- a/apps/web/app/api/admin/ai/route.ts
+++ b/apps/web/app/api/admin/ai/route.ts
@@ -1,91 +1,118 @@
 import { ApiError, apiHandler } from "@/lib/api";
 import { AIService, LOCAL_LLM_DEFAULTS } from "@/lib/core-modules/ai";
 import { AuditService } from "@/lib/services/audit-service";
+import {
+  urlValidationMessage,
+  validateHttpUrl,
+} from "@/lib/utils/url-validation";
 
 /**
  * GET /api/admin/ai
  * AI設定を取得（管理者のみ）
  */
-export const GET = apiHandler(async () => {
-  const config = await AIService.getConfig();
+export const GET = apiHandler(
+  async () => {
+    const config = await AIService.getConfig();
 
-  // APIキーはマスクして返す
-  return {
-    config: {
-      ...config,
-      apiKey: config.apiKey ? `***${config.apiKey.slice(-4)}` : null,
-      hasApiKey: !!config.apiKey,
-    },
-    localLLMDefaults: LOCAL_LLM_DEFAULTS,
-  };
-}, { admin: true });
+    // APIキーはマスクして返す
+    return {
+      config: {
+        ...config,
+        apiKey: config.apiKey ? `***${config.apiKey.slice(-4)}` : null,
+        hasApiKey: !!config.apiKey,
+      },
+      localLLMDefaults: LOCAL_LLM_DEFAULTS,
+    };
+  },
+  { admin: true },
+);
 
 /**
  * PATCH /api/admin/ai
  * AI設定を更新（管理者のみ）
  */
-export const PATCH = apiHandler(async (request, session) => {
-  const body = await request.json();
-  const {
-    enabled,
-    provider,
-    apiKey,
-    model,
-    localProvider,
-    localEndpoint,
-    localModel,
-  } = body;
-
-  await AIService.updateConfig({
-    ...(enabled !== undefined && { enabled }),
-    ...(provider !== undefined && { provider }),
-    ...(apiKey !== undefined && { apiKey }),
-    ...(model !== undefined && { model }),
-    ...(localProvider !== undefined && { localProvider }),
-    ...(localEndpoint !== undefined && { localEndpoint }),
-    ...(localModel !== undefined && { localModel }),
-  });
-
-  // 監査ログに記録
-  await AuditService.log({
-    action: "AI_CONFIG_UPDATE",
-    category: "SYSTEM_SETTING",
-    userId: session.user.id,
-    details: {
+export const PATCH = apiHandler(
+  async (request, session) => {
+    const body = await request.json();
+    const {
       enabled,
       provider,
+      apiKey,
       model,
       localProvider,
       localEndpoint,
       localModel,
-      apiKeyChanged: apiKey !== undefined,
-    },
-  }).catch(() => {});
+    } = body;
 
-  const config = await AIService.getConfig();
+    let normalizedLocalEndpoint: string | undefined;
+    if (localEndpoint !== undefined) {
+      const result = validateHttpUrl(localEndpoint);
+      if (!result.ok) {
+        throw ApiError.badRequest(
+          `Invalid endpoint URL: ${urlValidationMessage(result.reason, "en")}`,
+          `エンドポイントURLが無効です: ${urlValidationMessage(result.reason, "ja")}`,
+        );
+      }
+      normalizedLocalEndpoint = result.url;
+    }
 
-  return {
-    success: true,
-    config: {
-      ...config,
-      apiKey: config.apiKey ? `***${config.apiKey.slice(-4)}` : null,
-      hasApiKey: !!config.apiKey,
-    },
-  };
-}, { admin: true });
+    await AIService.updateConfig({
+      ...(enabled !== undefined && { enabled }),
+      ...(provider !== undefined && { provider }),
+      ...(apiKey !== undefined && { apiKey }),
+      ...(model !== undefined && { model }),
+      ...(localProvider !== undefined && { localProvider }),
+      ...(normalizedLocalEndpoint !== undefined && {
+        localEndpoint: normalizedLocalEndpoint,
+      }),
+      ...(localModel !== undefined && { localModel }),
+    });
+
+    // 監査ログに記録
+    await AuditService.log({
+      action: "AI_CONFIG_UPDATE",
+      category: "SYSTEM_SETTING",
+      userId: session.user.id,
+      details: {
+        enabled,
+        provider,
+        model,
+        localProvider,
+        localEndpoint: normalizedLocalEndpoint ?? localEndpoint,
+        localModel,
+        apiKeyChanged: apiKey !== undefined,
+      },
+    }).catch(() => {});
+
+    const config = await AIService.getConfig();
+
+    return {
+      success: true,
+      config: {
+        ...config,
+        apiKey: config.apiKey ? `***${config.apiKey.slice(-4)}` : null,
+        hasApiKey: !!config.apiKey,
+      },
+    };
+  },
+  { admin: true },
+);
 
 /**
  * POST /api/admin/ai
  * ローカルLLM接続テスト（管理者のみ）
  */
-export const POST = apiHandler(async (request) => {
-  const body = await request.json();
-  const { action } = body;
+export const POST = apiHandler(
+  async (request) => {
+    const body = await request.json();
+    const { action } = body;
 
-  if (action === "test-connection") {
-    const result = await AIService.testLocalConnection();
-    return result;
-  }
+    if (action === "test-connection") {
+      const result = await AIService.testLocalConnection();
+      return result;
+    }
 
-  throw ApiError.badRequest("Invalid action");
-}, { admin: true });
+    throw ApiError.badRequest("Invalid action");
+  },
+  { admin: true },
+);

--- a/apps/web/app/api/ai-playground/settings/route.ts
+++ b/apps/web/app/api/ai-playground/settings/route.ts
@@ -1,6 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import {
+  urlValidationMessage,
+  validateHttpUrl,
+} from "@/lib/utils/url-validation";
 
 const SETTINGS_KEYS = {
   LLM_CONFIG: "ai_playground_llm_config",
@@ -125,12 +129,39 @@ export async function PUT(request: NextRequest) {
     const updates: Array<{ key: string; value: string }> = [];
 
     for (const [key, value] of Object.entries(body)) {
-      if (validKeys.includes(key as (typeof validKeys)[number])) {
-        updates.push({
-          key,
-          value: typeof value === "string" ? value : JSON.stringify(value),
-        });
+      if (!validKeys.includes(key as (typeof validKeys)[number])) continue;
+
+      let normalized: unknown = value;
+      if (
+        (key === SETTINGS_KEYS.LLM_CONFIG ||
+          key === SETTINGS_KEYS.RAG_CONFIG) &&
+        value &&
+        typeof value === "object"
+      ) {
+        const cfg = { ...(value as Record<string, unknown>) };
+        if (typeof cfg.baseUrl === "string" && cfg.baseUrl.trim() !== "") {
+          const result = validateHttpUrl(cfg.baseUrl);
+          if (!result.ok) {
+            return NextResponse.json(
+              {
+                error: `Invalid baseUrl in ${key}: ${urlValidationMessage(result.reason, "en")}`,
+                errorJa: `${key} の URL が無効です: ${urlValidationMessage(result.reason, "ja")}`,
+              },
+              { status: 400 },
+            );
+          }
+          cfg.baseUrl = result.url;
+        }
+        normalized = cfg;
       }
+
+      updates.push({
+        key,
+        value:
+          typeof normalized === "string"
+            ? normalized
+            : JSON.stringify(normalized),
+      });
     }
 
     for (const update of updates) {

--- a/apps/web/lib/utils/url-validation.ts
+++ b/apps/web/lib/utils/url-validation.ts
@@ -1,0 +1,35 @@
+export type UrlValidationError = "empty" | "missing-scheme" | "invalid";
+
+export type UrlValidationResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: UrlValidationError };
+
+export function validateHttpUrl(value: string): UrlValidationResult {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return { ok: false, reason: "empty" };
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return { ok: false, reason: "missing-scheme" };
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.origin === "null") return { ok: false, reason: "invalid" };
+    return { ok: true, url: trimmed };
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+}
+
+export function urlValidationMessage(
+  reason: UrlValidationError,
+  language: "en" | "ja",
+): string {
+  const messages: Record<UrlValidationError, { en: string; ja: string }> = {
+    empty: { en: "URL is required", ja: "URL を入力してください" },
+    "missing-scheme": {
+      en: "URL must start with http:// or https://",
+      ja: "http:// または https:// で始まる URL を入力してください",
+    },
+    invalid: { en: "URL format is invalid", ja: "URL の形式が不正です" },
+  };
+  return messages[reason][language];
+}


### PR DESCRIPTION
## Summary

- **共有バリデータ** `apps/web/lib/utils/url-validation.ts` を新設。`http(s)://` 必須・`new URL()` 成功・`origin !== "null"` の 4 段チェックで、保存形式・スキーム欠落の両面を入力境界で防止。
- **サーバ防御** `/api/admin/ai` PATCH（`localEndpoint`）と `/api/ai-playground/settings` PUT（`ai_playground_llm_config.baseUrl` / `ai_playground_rag_config.baseUrl`）で 400 を返す。
- **クライアント UX** 管理画面の Endpoint URL / RAG Server URL Input にインラインエラーを表示。`localEndpoint` は blur 時に検証して PATCH（毎キー打鍵で PATCH していた既存挙動を実質的に改善）。

Closes #38

## 設計判断

- **方針 B（厳格 reject）を採用**。auto-prepend `http://` は typo を黙って通すリスクがあり、admin 設定は頻度低・誤りコスト高なので明示エラーが妥当。
- 既存設定で稀にスキームなしで保存されているデータは、次回 PATCH 時に弾かれる（実害なし — 現に動かない設定なので再入力を促す方向で問題なし）。

## ファイル別の変更内容

| ファイル | 変更 |
|---|---|
| `apps/web/lib/utils/url-validation.ts` | **新規** バリデータ + i18n メッセージ |
| `apps/web/__tests__/lib/utils/url-validation.test.ts` | **新規** 全 8 ケース（空・スキームなし・不正・各種正常系・末尾スラッシュ・case-insensitive） |
| `apps/web/app/api/admin/ai/route.ts` | PATCH の `localEndpoint` 検証 + 監査ログに正規化後の URL を記録 |
| `apps/web/app/api/ai-playground/settings/route.ts` | PUT の LLM/RAG config の `baseUrl` 検証 |
| `apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx` | URL Input にローカル state + 検証 + インラインエラー |

## 注意

`AiSettingsClient.tsx` は元コードに既存の Biome 違反（organizeImports + format）があり、本変更ついでに Biome に通しているため**差分が大きく見えます**。機能変更は endpoint/baseUrl 周辺の Input・state・useEffect・useCallback に限定。`git diff -w` で確認すると差分の大半が空白だと分かります。

## Test plan

- [x] `pnpm test --testPathPatterns=url-validation` — 全 8 件 pass
- [x] `pnpm exec biome check` — 変更ファイル clean
- [x] `pnpm exec tsc --noEmit` — 型エラーなし
- [ ] `/admin/ai-settings` で `localhost:8080`（スキームなし）を入力 → インラインエラー表示・PATCH 抑止
- [ ] 同画面で `http://localhost:8080/v1` 入力 → 末尾スラッシュ正規化されて保存
- [ ] curl で `PATCH /api/admin/ai` に `{"localEndpoint":"localhost:8080"}` → 400 + `errorJa`
- [ ] curl で `PUT /api/ai-playground/settings` に `{"ai_playground_rag_config":{"baseUrl":"localhost:8000",...}}` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)