### PR TITLE
fix(ai-settings): 全般タブ PATCH 失敗時にエラーを表示する (Issue #40)

### DIFF
--- a/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
+++ b/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
@@ -109,6 +109,7 @@ const translations = {
     save: "Save",
     saving: "Saving...",
     saved: "Saved",
+    saveFailed: "Failed to save",
   },
   ja: {
     generalTitle: "全般AI設定",
@@ -154,6 +155,7 @@ const translations = {
     save: "保存",
     saving: "保存中...",
     saved: "保存しました",
+    saveFailed: "保存に失敗しました",
   },
 };
 
@@ -239,10 +241,7 @@ export function AiSettingsClient({
         });
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
-          const message =
-            data.errorJa ||
-            data.error ||
-            (language === "ja" ? "保存に失敗しました" : "Failed to save");
+          const message = data.errorJa || data.error || t.saveFailed;
           setSaveError(message);
           return;
         }
@@ -253,14 +252,12 @@ export function AiSettingsClient({
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       } catch {
-        setSaveError(
-          language === "ja" ? "保存に失敗しました" : "Failed to save",
-        );
+        setSaveError(t.saveFailed);
       } finally {
         setSaving(false);
       }
     },
-    [language],
+    [t],
   );
 
   const handleTestGeneral = useCallback(async () => {
@@ -319,19 +316,18 @@ export function AiSettingsClient({
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        const message =
-          data.errorJa ||
-          data.error ||
-          (language === "ja" ? "保存に失敗しました" : "Failed to save");
+        const message = data.errorJa || data.error || t.saveFailed;
         setSaveError(message);
         return;
       }
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+    } catch {
+      setSaveError(t.saveFailed);
     } finally {
       setSaving(false);
     }
-  }, [searchConfig, ragConfig, systemPrompts, language]);
+  }, [searchConfig, ragConfig, systemPrompts, t]);
 
   const handleLocalEndpointChange = useCallback(
     (value: string) => {

--- a/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
+++ b/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
@@ -230,25 +230,37 @@ export function AiSettingsClient({
   const handleUpdateAiConfig = useCallback(
     async (updates: Partial<AIConfig & { apiKey?: string }>) => {
       setSaving(true);
+      setSaveError(null);
       try {
         const res = await fetch("/api/admin/ai", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(updates),
         });
-        if (res.ok) {
-          const data = await res.json();
-          setAiConfig(data.config);
-          setAiApiKeyInput("");
-          setGeneralTestResult(null);
-          setSaved(true);
-          setTimeout(() => setSaved(false), 2000);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          const message =
+            data.errorJa ||
+            data.error ||
+            (language === "ja" ? "保存に失敗しました" : "Failed to save");
+          setSaveError(message);
+          return;
         }
+        const data = await res.json();
+        setAiConfig(data.config);
+        setAiApiKeyInput("");
+        setGeneralTestResult(null);
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      } catch {
+        setSaveError(
+          language === "ja" ? "保存に失敗しました" : "Failed to save",
+        );
       } finally {
         setSaving(false);
       }
     },
-    [],
+    [language],
   );
 
   const handleTestGeneral = useCallback(async () => {
@@ -565,6 +577,12 @@ export function AiSettingsClient({
                 </Badge>
               )}
             </div>
+
+            {saveError && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {saveError}
+              </p>
+            )}
 
             <div
               className={`flex items-center gap-2 p-4 rounded-lg ${aiConfig.enabled ? "bg-green-50 dark:bg-green-950/30" : "bg-muted"}`}


### PR DESCRIPTION
## Summary

PR #39 で `handleSavePlayground` には `res.ok` チェック + `saveError` 表示を入れたが、全般タブの `handleUpdateAiConfig` に同等処理が抜けていた。同 PR で追加した URL バリデーションが 400 を返す経路でユーザがサイレント失敗するため修正。

- `handleUpdateAiConfig` に `res.ok` チェック + `errorJa`/`error` の取り込み + 例外 catch を追加
- 全般タブ Card 内に `saveError` 表示エリアを追加（Test Connection ボタン下）

Closes #40

## Test plan

- [x] `pnpm exec biome check` 変更ファイル clean
- [x] `pnpm exec tsc --noEmit` 型エラーなし
- [ ] `/admin/ai-settings` 全般タブで `localEndpoint` を `localhost:8080`（スキームなし）に編集 → 赤字エラー「エンドポイントURLが無効です: ...」表示
- [ ] 同タブで正常な値に戻す → エラーが消えて保存成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)