### PR TITLE
refactor(ai-playground): 公開 API を index.ts に集約 (Issue #41)

### DIFF
--- a/addons/ai-playground/package.json
+++ b/addons/ai-playground/package.json
@@ -7,9 +7,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./pages/AiPlaygroundPage": "./src/pages/AiPlaygroundPage.tsx",
-    "./src/prompts": "./src/prompts.ts",
-    "./src/types": "./src/types.ts"
+    "./pages/AiPlaygroundPage": "./src/pages/AiPlaygroundPage.tsx"
   },
   "dependencies": {
     "@lionframe/module-types": "workspace:*"

--- a/addons/ai-playground/src/index.ts
+++ b/addons/ai-playground/src/index.ts
@@ -1,17 +1,26 @@
 export { aiPlaygroundModule } from "./module";
+export {
+  DEFAULT_SYSTEM_PROMPTS,
+  buildExplainPrompt,
+  buildIdeaPrompt,
+  buildRAGPrompt,
+  buildSearchPrompt,
+  getSystemPrompt,
+} from "./prompts";
+export { DEFAULT_RAG_CONFIG, DEFAULT_SEARCH_CONFIG } from "./types";
 export type {
+  ChatMode,
+  ChatRequest,
+  GenerationMetrics,
   LLMConfig,
   LLMGenerateOptions,
   LLMResponse,
-  ChatMode,
-  ChatRequest,
   Message,
-  SearchResult,
-  SearchResponse,
-  SearchConfig,
+  RAGConfig,
   RAGContext,
   RAGQueryResponse,
-  RAGConfig,
+  SearchConfig,
+  SearchResponse,
+  SearchResult,
   SystemPrompts,
-  GenerationMetrics,
 } from "./types";

--- a/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
+++ b/apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import type {
-  RAGConfig,
-  SearchConfig,
-  SystemPrompts,
-} from "@lionframe/addon-ai-playground";
-import { DEFAULT_SYSTEM_PROMPTS } from "@lionframe/addon-ai-playground/src/prompts";
 import {
   DEFAULT_RAG_CONFIG,
   DEFAULT_SEARCH_CONFIG,
-} from "@lionframe/addon-ai-playground/src/types";
+  DEFAULT_SYSTEM_PROMPTS,
+  type RAGConfig,
+  type SearchConfig,
+  type SystemPrompts,
+} from "@lionframe/addon-ai-playground";
 import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/apps/web/app/api/ai-playground/chat/route.ts
+++ b/apps/web/app/api/ai-playground/chat/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest } from "next/server";
-import type { LLMConfig, LLMGenerateOptions, ChatRequest, ChatMode, SearchResult, RAGContext, SystemPrompts } from "@lionframe/addon-ai-playground";
 import {
-  getSystemPrompt as getPrompt,
   buildExplainPrompt,
   buildIdeaPrompt,
-  buildSearchPrompt,
   buildRAGPrompt,
-} from "@lionframe/addon-ai-playground/src/prompts";
+  buildSearchPrompt,
+  getSystemPrompt as getPrompt,
+  type ChatMode,
+  type ChatRequest,
+  type LLMConfig,
+  type LLMGenerateOptions,
+  type RAGContext,
+  type SearchResult,
+  type SystemPrompts,
+} from "@lionframe/addon-ai-playground";
 import { AIService } from "@/lib/core-modules/ai/services/ai-service";
 
 // --- Inline LLM Provider (server-only) ---


### PR DESCRIPTION
## Summary

`@lionframe/addon-ai-playground` の公開 API を `src/index.ts` に集約し、利用側の deep `./src/...` import を解消する。

- `DEFAULT_SYSTEM_PROMPTS` / `DEFAULT_RAG_CONFIG` / `DEFAULT_SEARCH_CONFIG` を index.ts から re-export
- プロンプトビルダー群 (`getSystemPrompt`, `buildExplainPrompt`, `buildIdeaPrompt`, `buildSearchPrompt`, `buildRAGPrompt`) も同様に re-export
- `package.json` の `./src/prompts` / `./src/types` サブパス export を削除
- 利用側 2 ファイル（`AiSettingsClient.tsx`, `api/ai-playground/chat/route.ts`）の import をパッケージ root に統一

`./pages/AiPlaygroundPage` のサブパス export は「専用ページの提供」という明示的な責務があり、Issue #41 でも「別件として残す判断もあり得ます」と記載されているため現状維持。

Closes #41

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `addons/ai-playground/src/index.ts` | 定数 + ビルダー関数を re-export 追加 |
| `addons/ai-playground/package.json` | `./src/...` サブパス export を 2 件削除 |
| `apps/web/app/(main)/(menus)/(admin)/admin/ai-settings/AiSettingsClient.tsx` | 3 個の import を 1 個に統合 |
| `apps/web/app/api/ai-playground/chat/route.ts` | 2 個の import を 1 個に統合 |

## Test plan

- [x] `pnpm exec tsc --noEmit` 型エラーなし
- [x] `grep -rn "@lionframe/addon-ai-playground/src" --include="*.ts" --include="*.tsx"` で内部 import が残っていないことを確認
- [ ] `/admin/ai-settings` の Playground タブが正常表示される（DEFAULT_SYSTEM_PROMPTS のリセット動作含む）
- [ ] AI Playground のチャット送信が成功する（chat/route.ts のプロンプト構築経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)