### PR TITLE
feat(ai-playground): SUGGESTIONS の差し替え API 追加 (Issue #44)

### DIFF
--- a/addons/ai-playground/src/index.ts
+++ b/addons/ai-playground/src/index.ts
@@ -1,4 +1,6 @@
 export { aiPlaygroundModule } from "./module";
+export { AiPlaygroundPage } from "./pages/AiPlaygroundPage";
+export type { AiPlaygroundPageProps } from "./pages/AiPlaygroundPage";
 export {
   DEFAULT_SYSTEM_PROMPTS,
   buildExplainPrompt,
@@ -7,7 +9,12 @@ export {
   buildSearchPrompt,
   getSystemPrompt,
 } from "./prompts";
-export { DEFAULT_RAG_CONFIG, DEFAULT_SEARCH_CONFIG } from "./types";
+export {
+  DEFAULT_RAG_CONFIG,
+  DEFAULT_SEARCH_CONFIG,
+  DEFAULT_SUGGESTIONS,
+  resolveSuggestions,
+} from "./types";
 export type {
   ChatMode,
   ChatRequest,
@@ -22,5 +29,9 @@ export type {
   SearchConfig,
   SearchResponse,
   SearchResult,
+  SuggestionMap,
+  Suggestions,
+  SuggestionsLanguage,
+  SuggestionsOverride,
   SystemPrompts,
 } from "./types";

--- a/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
+++ b/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
@@ -14,36 +14,32 @@ import type {
   SystemPrompts,
   SearchConfig,
   RAGConfig,
+  SuggestionsOverride,
 } from "../types";
 import {
   PROVIDER_PRESETS,
   CHAT_MODES,
   DEFAULT_SEARCH_CONFIG,
   DEFAULT_RAG_CONFIG,
+  resolveSuggestions,
 } from "../types";
 import { DEFAULT_SYSTEM_PROMPTS } from "../prompts";
 import { estimateTokenCount } from "../lib/token-utils";
 
 const DEFAULT_CONTEXT_WINDOW = 4096;
 
-const SUGGESTIONS = {
-  ja: {
-    free: ["今日の天気について教えて", "おすすめの本を紹介して", "面白い雑学を教えて"],
-    explain: ["プログラミングの「変数」って何？", "AIと機械学習の違いを教えて", "インターネットの仕組み"],
-    idea: ["高校生向けの学習アプリ", "社内コミュニケーション改善", "新入社員研修プログラム"],
-    search: ["2024年のAI技術トレンド", "リモートワークのベストプラクティス"],
-    rag: ["ナレッジベースの内容を教えて"],
-  },
-  en: {
-    free: ["Tell me about today's weather", "Recommend a good book", "Share an interesting fact"],
-    explain: ["What is a 'variable' in programming?", "Difference between AI and ML", "How does the internet work?"],
-    idea: ["Learning app for students", "Improving team communication", "New employee training program"],
-    search: ["AI technology trends 2024", "Remote work best practices"],
-    rag: ["Tell me about the knowledge base"],
-  },
-};
+export interface AiPlaygroundPageProps {
+  language: "en" | "ja";
+  // ホストアプリから既定のサンプルプロンプトを差し替えるためのオプション (Issue #44)。
+  // モード単位の差分マージ。特に rag モードは投入されたナレッジに依存するため、
+  // 各環境のナレッジに沿ったサンプルを提示するために利用する。
+  suggestionsOverride?: SuggestionsOverride;
+}
 
-export function AiPlaygroundPage({ language }: { language: "en" | "ja" }) {
+export function AiPlaygroundPage({
+  language,
+  suggestionsOverride,
+}: AiPlaygroundPageProps) {
   const llamaCppPreset = PROVIDER_PRESETS.find((p) => p.provider === "llama-cpp")!;
   const [llmConfig, setLlmConfig] = useState<LLMConfig>({
     provider: llamaCppPreset.provider,
@@ -344,7 +340,11 @@ export function AiPlaygroundPage({ language }: { language: "en" | "ja" }) {
   }
 
   const hasMessages = messages.length > 0 || isLoading;
-  const currentSuggestions = SUGGESTIONS[language][mode ?? "free"] || [];
+  const currentSuggestions = resolveSuggestions(
+    language,
+    mode ?? "free",
+    suggestionsOverride,
+  );
   const currentModeInfo = mode ? CHAT_MODES.find((m) => m.id === mode) : null;
 
   return (

--- a/addons/ai-playground/src/types.ts
+++ b/addons/ai-playground/src/types.ts
@@ -181,6 +181,44 @@ export interface SystemPrompts {
   rag: string;          // ナレッジ検索モード追加部分
 }
 
+// Suggestion Prompts Types (Issue #44: ホストアプリからモード別サンプルを差し替え可能に)
+//
+// `free` はモード未選択時のサンプル。`ChatMode` 各モード（explain/idea/search/rag）
+// と "free" の和集合をキーとする。すべてのモードを必ず提供する必要はない（差分マージ）。
+export type SuggestionsLanguage = "en" | "ja";
+export type SuggestionMap = Partial<Record<ChatMode | "free", readonly string[]>>;
+export type Suggestions = Record<SuggestionsLanguage, SuggestionMap>;
+export type SuggestionsOverride = Partial<Record<SuggestionsLanguage, SuggestionMap>>;
+
+export const DEFAULT_SUGGESTIONS: Suggestions = {
+  ja: {
+    free: ["今日の天気について教えて", "おすすめの本を紹介して", "面白い雑学を教えて"],
+    explain: ["プログラミングの「変数」って何？", "AIと機械学習の違いを教えて", "インターネットの仕組み"],
+    idea: ["高校生向けの学習アプリ", "社内コミュニケーション改善", "新入社員研修プログラム"],
+    search: ["2024年のAI技術トレンド", "リモートワークのベストプラクティス"],
+    rag: ["ナレッジベースの内容を教えて"],
+  },
+  en: {
+    free: ["Tell me about today's weather", "Recommend a good book", "Share an interesting fact"],
+    explain: ["What is a 'variable' in programming?", "Difference between AI and ML", "How does the internet work?"],
+    idea: ["Learning app for students", "Improving team communication", "New employee training program"],
+    search: ["AI technology trends 2024", "Remote work best practices"],
+    rag: ["Tell me about the knowledge base"],
+  },
+};
+
+// 既定のサンプルにホストアプリの override をモード単位でマージする。
+// override 側の配列が空でも「明示的に空にしたい」意図として尊重する。
+export function resolveSuggestions(
+  language: SuggestionsLanguage,
+  modeKey: ChatMode | "free",
+  override: SuggestionsOverride | undefined,
+): readonly string[] {
+  const overridden = override?.[language]?.[modeKey];
+  if (overridden !== undefined) return overridden;
+  return DEFAULT_SUGGESTIONS[language][modeKey] ?? [];
+}
+
 // Generation Metrics Types
 export interface GenerationMetrics {
   // コンテキスト情報

--- a/apps/web/app/(main)/(menus)/(guest)/ai-playground/page.tsx
+++ b/apps/web/app/(main)/(menus)/(guest)/ai-playground/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { getLanguage } from "@/lib/i18n/get-language";
-import { AiPlaygroundPage } from "@lionframe/addon-ai-playground/pages/AiPlaygroundPage";
+import { AiPlaygroundPage } from "@lionframe/addon-ai-playground";
 
 export const metadata: Metadata = {
   title: "AI Playground",


### PR DESCRIPTION
## Summary

- `AiPlaygroundPage` props に `suggestionsOverride` を追加。ホストアプリからモード別サンプルプロンプト（`free` / `explain` / `idea` / `search` / `rag`）を差し替え可能に。
- 既存の `SUGGESTIONS` を `DEFAULT_SUGGESTIONS` として公開し、`resolveSuggestions(language, modeKey, override)` ヘルパーで「override → default」を差分マージで解決。
- 公開 API（`index.ts`、Issue #41 で集約）に `AiPlaygroundPage` / `AiPlaygroundPageProps` / `SuggestionMap` / `Suggestions` / `SuggestionsLanguage` / `SuggestionsOverride` / `DEFAULT_SUGGESTIONS` / `resolveSuggestions` を追加。
- ホストアプリ側 (`apps/web/app/(main)/(menus)/(guest)/ai-playground/page.tsx`) の import を `@lionframe/addon-ai-playground/pages/AiPlaygroundPage` から公開 API（`@lionframe/addon-ai-playground`）に切り替え。

## API

```ts
import { AiPlaygroundPage, type SuggestionsOverride } from "@lionframe/addon-ai-playground";

const override: SuggestionsOverride = {
  ja: {
    rag: [
      "就業規則について教えて",
      "経費精算のフローは？",
      "BoX3 の主要メニューを教えて",
    ],
  },
};

<AiPlaygroundPage language={language} suggestionsOverride={override} />
```

- `suggestionsOverride` は `Partial<Record<"en" | "ja", SuggestionMap>>`
- `SuggestionMap` は `Partial<Record<ChatMode | "free", readonly string[]>>`
- 全モードを必ず提供する必要なし（差分マージ）
- `rag` モードは投入ナレッジに依存するため、各環境のナレッジに沿ったサンプルを提示できる

## 動作

- `suggestionsOverride` 未指定 → 既存の `DEFAULT_SUGGESTIONS` を使用（後方互換）
- `suggestionsOverride.ja.rag = ["A", "B"]` → `rag` モードでは `["A", "B"]` が表示される
- `suggestionsOverride.ja.rag` のみ指定（他モード未指定）→ `rag` 以外は default のまま
- 空配列 `[]` を渡せば「明示的に空にしたい」意図として尊重（無効化用途）

## Test plan

- [x] `pnpm jest` 全 306 件パス
- [x] `npx tsc --noEmit` 型エラーなし
- [ ] dev サーバ起動 → AI Playground で各モード切替時にサンプルが表示されること（手動）
- [ ] 派生プロジェクトで `suggestionsOverride` を渡した時に rag モードのサンプルが上書きされること（手動）

## 関連

- Closes #44
- 関連 Issue: #41（公開 API を index.ts に集約。本 PR で `AiPlaygroundPage` も index.ts 経由で利用するように切替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)