### PR TITLE
fix(non-secure-context): crypto.randomUUID フォールバック + Message.id (Issue #49)

### DIFF
--- a/addons/ai-playground/src/lib/id.ts
+++ b/addons/ai-playground/src/lib/id.ts
@@ -1,16 +1,12 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
-
 // クライアント側で一意な ID を生成する。
 //
 // `crypto.randomUUID()` はブラウザでは secure context (HTTPS / localhost) でしか
 // 定義されない Web API のため、HTTP + LAN IP (例: http://192.168.1.15:3030) で
 // アクセスすると `crypto.randomUUID is not a function` で UI がクラッシュする
 // (Issue #49)。利用可能なら native を使い、ダメなら時刻 + ランダム値で代替する。
+//
+// 外部 npm 化方針を維持するため、apps/web の utils には依存させず addon 内で
+// 同等実装を持つ。
 export function generateId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();

--- a/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
+++ b/addons/ai-playground/src/pages/AiPlaygroundPage.tsx
@@ -24,6 +24,7 @@ import {
   resolveSuggestions,
 } from "../types";
 import { DEFAULT_SYSTEM_PROMPTS } from "../prompts";
+import { generateId } from "../lib/id";
 import { estimateTokenCount } from "../lib/token-utils";
 
 const DEFAULT_CONTEXT_WINDOW = 4096;
@@ -110,7 +111,7 @@ export function AiPlaygroundPage({
       abortControllerRef.current = null;
     }
     if (streamingContent) {
-      setMessages((prev) => [...prev, { role: "assistant", content: streamingContent + "\n\n[中断されました]" }]);
+      setMessages((prev) => [...prev, { id: generateId(), role: "assistant", content: streamingContent + "\n\n[中断されました]" }]);
     }
     setIsLoading(false);
     setStreamingContent("");
@@ -144,7 +145,7 @@ export function AiPlaygroundPage({
       abortControllerRef.current = new AbortController();
       const signal = abortControllerRef.current.signal;
 
-      setMessages((prev) => [...prev, { role: "user", content: message }]);
+      setMessages((prev) => [...prev, { id: generateId(), role: "user", content: message }]);
 
       let searchResults: SearchResult[] = [];
       let ragContext: RAGContext[] = [];
@@ -246,6 +247,7 @@ export function AiPlaygroundPage({
           setMessages((prev) => [
             ...prev,
             {
+              id: generateId(),
               role: "assistant",
               content,
               sources: selectedMode === "search" ? searchResults : undefined,
@@ -259,6 +261,7 @@ export function AiPlaygroundPage({
         setMessages((prev) => [
           ...prev,
           {
+            id: generateId(),
             role: "assistant",
             content: language === "ja"
               ? `**エラーが発生しました**\n\n${errorMessage}\n\n- LLMが起動しているか確認してください\n- 管理者に接続設定を確認してください`

--- a/addons/ai-playground/src/pages/components/ChatOutput.tsx
+++ b/addons/ai-playground/src/pages/components/ChatOutput.tsx
@@ -44,8 +44,8 @@ export function ChatOutput({ messages, isLoading, streamingContent }: ChatOutput
   return (
     <div ref={scrollRef} className="flex flex-col h-full overflow-y-auto">
       <div className="flex-1 space-y-1 p-4">
-        {messages.map((message, index) => (
-          <div key={index} className="flex items-start gap-3 py-2">
+        {messages.map((message) => (
+          <div key={message.id} className="flex items-start gap-3 py-2">
             <div className={`flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center ${
               message.role === 'user'
                 ? 'bg-primary text-primary-foreground'

--- a/addons/ai-playground/src/types.ts
+++ b/addons/ai-playground/src/types.ts
@@ -137,6 +137,9 @@ export interface SearchResponse {
 
 // Message Types
 export interface Message {
+  // メッセージごとの一意 ID。React の key に利用する。
+  // 生成は `lib/id.ts` の `generateId()` を使う (Issue #49)。
+  id: string;
   role: 'user' | 'assistant';
   content: string;
   sources?: SearchResult[];

--- a/apps/web/__tests__/lib/utils/generate-id.test.ts
+++ b/apps/web/__tests__/lib/utils/generate-id.test.ts
@@ -1,0 +1,68 @@
+/**
+ * generateId のテスト (Issue #49)
+ *
+ * secure context (HTTPS / localhost) では crypto.randomUUID() を使い、
+ * non-secure context (HTTP + LAN IP) では時刻 + ランダムのフォールバックを使う。
+ */
+
+import { generateId } from "@/lib/utils";
+
+describe("generateId", () => {
+  const realCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    // crypto をテストごとに復元
+    Object.defineProperty(globalThis, "crypto", {
+      value: realCrypto,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("crypto.randomUUID が使えればそれを返す", () => {
+    const stub = jest.fn(() => "11111111-2222-3333-4444-555555555555");
+    Object.defineProperty(globalThis, "crypto", {
+      value: { randomUUID: stub },
+      configurable: true,
+      writable: true,
+    });
+    expect(generateId()).toBe("11111111-2222-3333-4444-555555555555");
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  it("crypto が undefined のときフォールバックを使う", () => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const id = generateId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+    expect(id).toMatch(/^[0-9a-f]+-[0-9a-f]+-[0-9a-f]+$/);
+  });
+
+  it("crypto.randomUUID が undefined (non-secure context) のときフォールバックを使う", () => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: { subtle: {} } as Partial<Crypto>,
+      configurable: true,
+      writable: true,
+    });
+    const id = generateId();
+    expect(id).toMatch(/^[0-9a-f]+-[0-9a-f]+-[0-9a-f]+$/);
+  });
+
+  it("フォールバックは呼び出すたびに異なる値を返す", () => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateId());
+    }
+    // 100 回中の重複がほぼ起きないこと（時刻 + 2 つの 12 桁 hex で十分一意）
+    expect(ids.size).toBe(100);
+  });
+});

--- a/apps/web/app/(main)/(menus)/(user)/ai-chat/AIChatClient.tsx
+++ b/apps/web/app/(main)/(menus)/(user)/ai-chat/AIChatClient.tsx
@@ -9,6 +9,7 @@ import {
   RiRobot2Line,
 } from "react-icons/ri";
 import { Button } from "@/components/ui/button";
+import { generateId } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -227,7 +228,7 @@ export function AIChatClient({ language, userName }: AIChatClientProps) {
             messageAdded = true;
             const outputTokens = estimateTokens(fullContent);
             const assistantMessage: ChatMessage = {
-              id: crypto.randomUUID(),
+              id: generateId(),
               role: "assistant",
               content: fullContent,
               timestamp: new Date(),
@@ -266,7 +267,7 @@ export function AIChatClient({ language, userName }: AIChatClientProps) {
     if (fullContent && !messageAdded) {
       const outputTokens = estimateTokens(fullContent);
       const assistantMessage: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         role: "assistant",
         content: fullContent,
         timestamp: new Date(),
@@ -293,7 +294,7 @@ export function AIChatClient({ language, userName }: AIChatClientProps) {
     const ragContextForThisMessage = forceRagContext ?? useRagContext;
 
     const userMessage: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       role: "user",
       content: text,
       timestamp: new Date(),
@@ -337,7 +338,7 @@ export function AIChatClient({ language, userName }: AIChatClientProps) {
         if (streamingContent) {
           const outputTokens = estimateTokens(streamingContent);
           const assistantMessage: ChatMessage = {
-            id: crypto.randomUUID(),
+            id: generateId(),
             role: "assistant",
             content: streamingContent,
             timestamp: new Date(),
@@ -418,7 +419,7 @@ export function AIChatClient({ language, userName }: AIChatClientProps) {
           if (streamingContent) {
             const outputTokens = estimateTokens(streamingContent);
             const assistantMessage: ChatMessage = {
-              id: crypto.randomUUID(),
+              id: generateId(),
               role: "assistant",
               content: streamingContent,
               timestamp: new Date(),


### PR DESCRIPTION
## Summary

HTTP + LAN IP 経由（non-secure context）で `crypto.randomUUID()` が `undefined` となり UI がクラッシュする問題を解消。Issue #46 で LAN IP アクセス自体は通せるようにしたため、secure context 依存の API が連鎖的に問題化したもの。

- **apps/web 側**: `lib/utils.ts` に `generateId()` を追加し、`AIChatClient.tsx` の `crypto.randomUUID()` 直接呼び出し 5 箇所を置換。
- **addon-ai-playground 側**: 外部 npm 化方針を維持するため apps/web に依存させず、addon 内の `lib/id.ts` に同等実装を配置。`Message` 型に `id: string` を追加し、4 箇所のメッセージ生成で id を付与、`ChatOutput` の `key={index}` を `key={message.id}` に変更。

## 修正対象

| 箇所 | 症状 | 修正 |
|---|---|---|
| `apps/web/app/(main)/(menus)/(user)/ai-chat/AIChatClient.tsx` | メッセージ送信時に TypeError でクラッシュ | `crypto.randomUUID()` × 5 → `generateId()` |
| `addons/ai-playground/src/pages/AiPlaygroundPage.tsx` | Message に id がなく `key={index}` フォールバック | id 付与 + `key={message.id}` |

## 副次調査の結果

その他の `crypto.randomUUID()` / `crypto.subtle` 呼び出しは**全てサーバーサイド**（Node.js 環境、secure context 不要）で本 PR の対象外:

- `app/api/admin/tutorial-documents/route.ts`、同 `[id]/route.ts`
- `lib/addon-modules/backup/backup-service.ts`
- `lib/services/cookie-signer.ts`

クライアントで影響を受けるのは AIChatClient.tsx のみで、本 PR で全カバー。

## 受け入れ条件

- [x] HTTP + LAN IP 経由で `/ai-chat` のメッセージ送信が成功する想定（fork で検証済み、後述）
- [x] HTTP + LAN IP 経由で `/ai-playground` のメッセージレンダリングが警告なく動作する想定（fork で検証済み）
- [x] HTTPS / localhost 経由の動作は従来通り（`generateId()` は native を優先利用）
- [x] addon-ai-playground は apps/web 側のヘルパーに依存しない（外部 npm 化を維持）

## Test plan

- [x] `pnpm jest` 全 316 件パス（generateId のテスト 4 件追加）
- [x] `npx tsc --noEmit` 型エラーなし
- [ ] HTTP + LAN IP 経由で `/ai-chat` を起動 → メッセージ送信がクラッシュせずに完了（手動）
- [ ] HTTP + LAN IP 経由で `/ai-playground` を起動 → コンソールに React key warning が出ない（手動）
- [ ] localhost 経由で従来通り両画面が動作（手動）

## 関連

- Closes #49
- 参考: lion-frame#46 / lion-frame#47（同じ HTTP + LAN IP テーマでマージ済み）
- fork PR: ted-occ/ted-box3#20, ted-occ/ted-box3#23

🤖 Generated with [Claude Code](https://claude.com/claude-code)