### PR TITLE
fix(ai/local-provider): thinking モデルの max_tokens 切れに専用エラー (Issue #51)

### DIFF
--- a/apps/web/__tests__/lib/core-modules/ai/local-provider.test.ts
+++ b/apps/web/__tests__/lib/core-modules/ai/local-provider.test.ts
@@ -1,0 +1,159 @@
+/**
+ * local-provider のテスト (OpenAI 互換ブランチ)
+ *
+ * Issue #51: thinking モデル (Gemma thinking, gpt-oss, DeepSeek-R1 等) が
+ * reasoning_content に思考を出して max_tokens を使い切ると content が空で
+ * 返るが、その場合に呼び出し側へ原因が伝わるエラーを投げることを検証する。
+ */
+
+import {
+  chatWithLocal,
+  generateWithLocal,
+  translateWithLocal,
+} from "@/lib/core-modules/ai/providers/local-provider";
+import type { AIConfig } from "@/lib/core-modules/ai/types";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const baseConfig: AIConfig = {
+  enabled: true,
+  provider: "local",
+  apiKey: null,
+  model: "",
+  localProvider: "lm-studio",
+  localEndpoint: "http://localhost:1234/v1/chat/completions",
+  localModel: "gemma-thinking-test",
+};
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+});
+
+describe("local-provider OpenAI 互換ブランチ", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("thinking モデルが max_tokens を使い切ったケース", () => {
+    const thinkingTruncatedBody = {
+      choices: [
+        {
+          message: {
+            content: "",
+            reasoning_content: "x".repeat(5000),
+          },
+          finish_reason: "length",
+        },
+      ],
+      usage: { completion_tokens: 2000 },
+    };
+
+    it("generateWithLocal: モデル名・consumed token・対処法を含むエラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(thinkingTruncatedBody));
+
+      await expect(
+        generateWithLocal(
+          [{ role: "user", content: "hi" }],
+          baseConfig,
+          0.1,
+          2000,
+        ),
+      ).rejects.toThrow(/gemma-thinking-test/);
+
+      mockFetch.mockResolvedValueOnce(okResponse(thinkingTruncatedBody));
+      await expect(
+        generateWithLocal(
+          [{ role: "user", content: "hi" }],
+          baseConfig,
+          0.1,
+          2000,
+        ),
+      ).rejects.toThrow(/max_tokens/);
+    });
+
+    it("chatWithLocal: thinking 専用エラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(thinkingTruncatedBody));
+
+      await expect(
+        chatWithLocal([{ role: "user", content: "hi" }], baseConfig),
+      ).rejects.toThrow(/thinking/);
+    });
+
+    it("translateWithLocal: thinking 専用エラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce(okResponse(thinkingTruncatedBody));
+
+      await expect(
+        translateWithLocal(
+          { text: "hello", sourceLanguage: "en", targetLanguage: "ja" },
+          baseConfig,
+        ),
+      ).rejects.toThrow(/thinking/);
+    });
+  });
+
+  describe("通常モデルが max_tokens を使い切ったケース (reasoning_content なし)", () => {
+    it("max_tokens を増やすよう案内するエラーを投げる", async () => {
+      mockFetch.mockResolvedValueOnce(
+        okResponse({
+          choices: [
+            { message: { content: "" }, finish_reason: "length" },
+          ],
+          usage: { completion_tokens: 2000 },
+        }),
+      );
+
+      await expect(
+        generateWithLocal(
+          [{ role: "user", content: "hi" }],
+          baseConfig,
+          0.1,
+          2000,
+        ),
+      ).rejects.toThrow(/max_tokens/);
+    });
+  });
+
+  describe("正常レスポンス", () => {
+    it("generateWithLocal: content がそのまま返る", async () => {
+      mockFetch.mockResolvedValueOnce(
+        okResponse({
+          choices: [
+            { message: { content: "  result text  " }, finish_reason: "stop" },
+          ],
+          usage: { completion_tokens: 5 },
+        }),
+      );
+
+      const result = await generateWithLocal(
+        [{ role: "user", content: "hi" }],
+        baseConfig,
+        0.1,
+        2000,
+      );
+
+      expect(result.output).toBe("result text");
+      expect(result.provider).toBe("local");
+    });
+
+    it("chatWithLocal: content がそのまま返る", async () => {
+      mockFetch.mockResolvedValueOnce(
+        okResponse({
+          choices: [
+            { message: { content: "hello" }, finish_reason: "stop" },
+          ],
+        }),
+      );
+
+      const result = await chatWithLocal(
+        [{ role: "user", content: "hi" }],
+        baseConfig,
+      );
+
+      expect(result.message).toBe("hello");
+    });
+  });
+});

--- a/apps/web/app/api/calendar/holidays/generate/route.ts
+++ b/apps/web/app/api/calendar/holidays/generate/route.ts
@@ -49,6 +49,8 @@ Return ONLY the JSON array, no other text.`;
     input,
     systemPrompt,
     temperature: 0.1,
+    // thinking モデルが reasoning に消費するぶんを見越した安全マージン (Issue #51)
+    maxTokens: 8000,
   });
 
   // Parse AI response

--- a/apps/web/lib/core-modules/ai/providers/local-provider.ts
+++ b/apps/web/lib/core-modules/ai/providers/local-provider.ts
@@ -24,6 +24,74 @@ function getOpenAIBase(endpoint: string): string {
   }
 }
 
+/**
+ * OpenAI 互換 API のレスポンスから content を取り出し、空だった場合は
+ * thinking モデル（reasoning_content を返すモデル）の打ち切りなど
+ * 原因を含む専用エラーを投げる。
+ *
+ * thinking モデル（Gemma thinking, gpt-oss, DeepSeek-R1 等）は
+ * `reasoning_content` に思考を出力したあと `max_tokens` を使い切ると
+ * `content` 空 + `finish_reason="length"` で返ってくる。
+ * Issue #51 参照。
+ */
+function extractOpenAICompatibleContent(
+  data: unknown,
+  context: { provider: string; model: string; maxTokens: number },
+): string {
+  const choice = (data as { choices?: Array<Record<string, unknown>> })
+    ?.choices?.[0];
+  const message = choice?.message as
+    | { content?: unknown; reasoning_content?: unknown }
+    | undefined;
+  const content =
+    typeof message?.content === "string" ? message.content.trim() : "";
+
+  if (content) {
+    return content;
+  }
+
+  const finishReason =
+    typeof choice?.finish_reason === "string" ? choice.finish_reason : "";
+  const usage = (data as { usage?: Record<string, unknown> })?.usage;
+  const completionTokens =
+    typeof usage?.completion_tokens === "number" ? usage.completion_tokens : 0;
+  const reasoningContent =
+    typeof message?.reasoning_content === "string"
+      ? message.reasoning_content
+      : "";
+  const reasoningLen = reasoningContent.length;
+
+  // thinking モデルが思考だけ出して max_tokens を使い切ったケース
+  if (
+    reasoningLen > 0 &&
+    finishReason === "length" &&
+    completionTokens >= context.maxTokens
+  ) {
+    throw new Error(
+      `${context.provider} のモデル「${context.model}」は thinking/reasoning モデルのため、` +
+        `思考の出力で max_tokens (${context.maxTokens}) を使い切り本文が返りませんでした` +
+        ` (completion_tokens=${completionTokens}, reasoning_len=${reasoningLen}, finish_reason=length)。` +
+        `対処: max_tokens を増やすか、thinking なしのモデルに切り替えてください。`,
+    );
+  }
+
+  // length 切りだが reasoning は無い（普通のモデルでも token 不足）
+  if (finishReason === "length" && completionTokens >= context.maxTokens) {
+    throw new Error(
+      `${context.provider} のモデル「${context.model}」が max_tokens (${context.maxTokens}) を使い切り` +
+        ` 本文が返りませんでした (completion_tokens=${completionTokens}, finish_reason=length)。` +
+        `対処: max_tokens を増やしてください。`,
+    );
+  }
+
+  // それ以外（フィルタリングなど）
+  throw new Error(
+    `${context.provider} から本文が返りませんでした` +
+      ` (finish_reason=${finishReason || "unknown"}, completion_tokens=${completionTokens}` +
+      `${reasoningLen > 0 ? `, reasoning_len=${reasoningLen}` : ""}).`,
+  );
+}
+
 function getOllamaBase(endpoint: string): string {
   const trimmed = endpoint.trim().replace(/\/+$/, "");
   try {
@@ -181,6 +249,7 @@ async function translateWithOpenAICompatible(
   sourceLang: string,
   targetLang: string,
 ): Promise<TranslateResponse> {
+  const maxTokens = 1000;
   const response = await fetch(
     `${getOpenAIBase(config.localEndpoint)}/chat/completions`,
     {
@@ -199,7 +268,7 @@ async function translateWithOpenAICompatible(
           },
         ],
         temperature: 0.3,
-        max_tokens: 1000,
+        max_tokens: maxTokens,
       }),
     },
   );
@@ -210,11 +279,11 @@ async function translateWithOpenAICompatible(
   }
 
   const data = await response.json();
-  const translatedText = data.choices?.[0]?.message?.content?.trim();
-
-  if (!translatedText) {
-    throw new Error(`No translation received from ${config.localProvider}`);
-  }
+  const translatedText = extractOpenAICompatibleContent(data, {
+    provider: config.localProvider,
+    model: config.localModel || "default",
+    maxTokens,
+  });
 
   return {
     translatedText,
@@ -298,6 +367,7 @@ async function chatWithOpenAICompatible(
   messages: ChatMessage[],
   config: AIConfig,
 ): Promise<ChatResponse> {
+  const maxTokens = 2000;
   const response = await fetch(
     `${getOpenAIBase(config.localEndpoint)}/chat/completions`,
     {
@@ -307,7 +377,7 @@ async function chatWithOpenAICompatible(
         model: config.localModel || "default",
         messages,
         temperature: 0.7,
-        max_tokens: 2000,
+        max_tokens: maxTokens,
       }),
     },
   );
@@ -318,11 +388,11 @@ async function chatWithOpenAICompatible(
   }
 
   const data = await response.json();
-  const message = data.choices?.[0]?.message?.content?.trim();
-
-  if (!message) {
-    throw new Error(`No response received from ${config.localProvider}`);
-  }
+  const message = extractOpenAICompatibleContent(data, {
+    provider: config.localProvider,
+    model: config.localModel || "default",
+    maxTokens,
+  });
 
   return {
     message,
@@ -438,11 +508,11 @@ export async function generateWithLocal(
   }
 
   const data = await response.json();
-  const output = data.choices?.[0]?.message?.content?.trim();
-
-  if (!output) {
-    throw new Error(`No response received from ${config.localProvider}`);
-  }
+  const output = extractOpenAICompatibleContent(data, {
+    provider: config.localProvider,
+    model: config.localModel || "default",
+    maxTokens,
+  });
 
   return {
     output,


### PR DESCRIPTION
Closes #51

## Summary

- LM Studio / llama.cpp 経由で thinking モデル（Gemma thinking, gpt-oss, DeepSeek-R1 等）を使うと `reasoning_content` に思考を出した後 `max_tokens` を使い切り、`content` 空 + `finish_reason="length"` で打ち切られるが、従来は呼び出し側に `No response received from ...` しか伝わらなかった。
- `local-provider.ts` の OpenAI 互換 3 ブランチ（translate / chat / generate）を共通ヘルパー `extractOpenAICompatibleContent` に統一。`reasoning_content` の有無 + `finish_reason` + `completion_tokens` / `max_tokens` を見て、モデル名・消費 token・対処法（max_tokens 増 / thinking なしモデルへ切替）を含む専用エラーを投げる。
- 祝日生成 API（重いプロンプト）に `maxTokens: 8000` を明示指定。
- local-provider 単体テスト 6 件を追加。

## Test plan

- [x] `pnpm exec jest __tests__/lib/core-modules/ai __tests__/api/ai` → 62 件パス（うち新規 6 件）
- [x] `pnpm exec tsc --noEmit` → エラーなし
- [ ] LM Studio に thinking モデル（Gemma-4 thinking 等）をロードして `/api/calendar/holidays/generate` を叩き、エラー時に「max_tokens を増やすか thinking なしモデルへ切替」と案内が出ることを確認
- [ ] 同 API で 8000 token に増やした結果、祝日 JSON が正常に返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)