### PR TITLE
fix(holidays): AI 祝日生成のエラー詳細を画面まで届ける (Issue #51 続報)

### DIFF
--- a/apps/web/__tests__/api/calendar/holidays-generate.test.ts
+++ b/apps/web/__tests__/api/calendar/holidays-generate.test.ts
@@ -1,0 +1,126 @@
+/**
+ * /api/calendar/holidays/generate のエラーハンドリングテスト
+ *
+ * Issue #51 関連: AIService が thinking モデル切れ等で詳細なエラーを
+ * 投げた場合に、apiHandler の汎用 500 ハンドラで握り潰されず、画面まで
+ * メッセージが届くことを検証する。
+ */
+
+import { POST } from "@/app/api/calendar/holidays/generate/route";
+import { auth } from "@/auth";
+import { AIService } from "@/lib/core-modules/ai";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/auth");
+jest.mock("@/lib/core-modules/ai");
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    holiday: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const mockAuth = auth as jest.MockedFunction<typeof auth>;
+const mockGenerate = AIService.generate as jest.MockedFunction<
+  typeof AIService.generate
+>;
+
+const mockAdminSession = {
+  user: { id: "admin-1", email: "admin@example.com", role: "ADMIN" },
+  expires: "2099-01-01",
+};
+
+const createRequest = (body: unknown) =>
+  new Request("http://localhost:3000/api/calendar/holidays/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/calendar/holidays/generate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue(mockAdminSession as never);
+  });
+
+  describe("AIエラーの画面伝達 (Issue #51)", () => {
+    it("AIService が thinking モデル切れエラーを投げた場合、400 + 元メッセージを返す", async () => {
+      const detailedMessage =
+        "lm-studio のモデル「gemma-thinking」は thinking/reasoning モデルのため、" +
+        "思考の出力で max_tokens (8000) を使い切り本文が返りませんでした。" +
+        "対処: max_tokens を増やすか、thinking なしのモデルに切り替えてください。";
+      mockGenerate.mockRejectedValue(new Error(detailedMessage));
+
+      const response = await POST(createRequest({ year: 2026 }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      // apiHandler は ApiError.toJSON() で error / errorJa を返す
+      expect(json.error).toBe(detailedMessage);
+      expect(json.errorJa).toBe(detailedMessage);
+    });
+
+    it("AIService が任意の Error を投げた場合も 500 ではなく 400 + 本文を返す", async () => {
+      mockGenerate.mockRejectedValue(new Error("connection refused"));
+
+      const response = await POST(createRequest({ year: 2026 }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toBe("connection refused");
+    });
+
+    it("AIService が JSON ではない文字列を返した場合、400 + 解析失敗メッセージを返す", async () => {
+      mockGenerate.mockResolvedValue({
+        output: "ここは JSON ではありません",
+        provider: "local",
+        model: "lm-studio/test",
+      });
+
+      const response = await POST(createRequest({ year: 2026 }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toContain("JSON");
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("year 未指定なら 400", async () => {
+      const response = await POST(createRequest({}));
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("正常系", () => {
+    it("AIService が正しい JSON を返したら祝日を作成して返す", async () => {
+      mockGenerate.mockResolvedValue({
+        output: JSON.stringify([
+          {
+            date: "2026-01-01",
+            name: "元日",
+            nameEn: "New Year's Day",
+            type: "national",
+          },
+        ]),
+        provider: "local",
+        model: "lm-studio/test",
+      });
+      (prisma.holiday.create as jest.Mock).mockResolvedValue({
+        id: "h1",
+        date: new Date("2026-01-01"),
+        name: "元日",
+        nameEn: "New Year's Day",
+        type: "national",
+      });
+
+      const response = await POST(createRequest({ year: 2026 }));
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.generated).toBe(1);
+      expect(json.holidays).toHaveLength(1);
+    });
+  });
+});

--- a/apps/web/app/(main)/admin/holidays/HolidayManagementClient.tsx
+++ b/apps/web/app/(main)/admin/holidays/HolidayManagementClient.tsx
@@ -93,6 +93,7 @@ export function HolidayManagementClient({
   const [generateYear, setGenerateYear] = useState(String(currentYear));
   const [generating, setGenerating] = useState(false);
   const [generateResult, setGenerateResult] = useState<string | null>(null);
+  const [generateResultIsError, setGenerateResultIsError] = useState(false);
 
   // Translate state
   const [translating, setTranslating] = useState(false);
@@ -205,6 +206,7 @@ export function HolidayManagementClient({
   const handleGenerate = useCallback(async () => {
     setGenerating(true);
     setGenerateResult(null);
+    setGenerateResultIsError(false);
     try {
       const res = await fetch("/api/calendar/holidays/generate", {
         method: "POST",
@@ -215,13 +217,28 @@ export function HolidayManagementClient({
         const data = await res.json();
         const msg = t.generateSuccess.replace("{count}", String(data.generated));
         setGenerateResult(msg);
+        setGenerateResultIsError(false);
         setFilterYear(generateYear);
         fetchHolidays();
       } else {
-        setGenerateResult(t.error);
+        // サーバー側で ApiError として返ってきた具体的なメッセージを表示する
+        // (Issue #51 の thinking モデル切れエラーなど)。
+        let detail: string = t.error;
+        try {
+          const data = (await res.json()) as {
+            errorJa?: string;
+            error?: string;
+          };
+          detail = data.errorJa || data.error || t.error;
+        } catch {
+          // ボディが JSON でない場合はフォールバック
+        }
+        setGenerateResult(detail);
+        setGenerateResultIsError(true);
       }
     } catch {
       setGenerateResult(t.error);
+      setGenerateResultIsError(true);
     } finally {
       setGenerating(false);
     }
@@ -503,7 +520,13 @@ export function HolidayManagementClient({
           </div>
 
           {generateResult && (
-            <p className="text-sm font-medium text-green-600 dark:text-green-400">
+            <p
+              className={`text-sm font-medium whitespace-pre-line ${
+                generateResultIsError
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-green-600 dark:text-green-400"
+              }`}
+            >
               {generateResult}
             </p>
           )}
@@ -514,6 +537,7 @@ export function HolidayManagementClient({
               onClick={() => {
                 setGenerateOpen(false);
                 setGenerateResult(null);
+                setGenerateResultIsError(false);
               }}
               disabled={generating}
             >

--- a/apps/web/app/api/calendar/holidays/generate/route.ts
+++ b/apps/web/app/api/calendar/holidays/generate/route.ts
@@ -45,13 +45,22 @@ Return ONLY the JSON array, no other text.`;
   const systemPrompt =
     "You are a helpful assistant that generates accurate Japanese holiday data. Return only valid JSON arrays with no markdown formatting or additional text.";
 
-  const result = await AIService.generate({
-    input,
-    systemPrompt,
-    temperature: 0.1,
-    // thinking モデルが reasoning に消費するぶんを見越した安全マージン (Issue #51)
-    maxTokens: 8000,
-  });
+  // AI 呼び出し: provider 側のエラー (例: thinking モデルの max_tokens 切れ)
+  // を画面に伝えるため、apiHandler の汎用 500 ハンドラで握り潰されないよう
+  // ApiError として再 throw する。
+  let result: Awaited<ReturnType<typeof AIService.generate>>;
+  try {
+    result = await AIService.generate({
+      input,
+      systemPrompt,
+      temperature: 0.1,
+      // thinking モデルが reasoning に消費するぶんを見越した安全マージン (Issue #51)
+      maxTokens: 8000,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw ApiError.badRequest(message, message);
+  }
 
   // Parse AI response
   let holidays: Array<{
@@ -75,7 +84,10 @@ Return ONLY the JSON array, no other text.`;
     holidays = JSON.parse(jsonStr);
   } catch {
     console.error("Failed to parse AI response:", result.output);
-    throw new Error("Failed to parse AI response");
+    throw ApiError.badRequest(
+      "AI から返ったレスポンスを JSON として解析できませんでした。モデルやプロンプトを見直してください。",
+      "AI から返ったレスポンスを JSON として解析できませんでした。モデルやプロンプトを見直してください。",
+    );
   }
 
   // Validate and insert holidays


### PR DESCRIPTION
Refs #51

## 背景

Issue #51 で local-provider が thinking モデル切れ等の詳しいエラーを投げるようにしたが、祝日生成画面では依然として「データの読み込みに失敗しました」しか出ない事象が発生（BoX3 のスクリーンショットで確認）。原因を辿ったところ、メッセージは **2 段階で握り潰されていた**。

| 段階 | 場所 | 何が起きていたか |
|------|------|------------------|
| 1 | \`lib/api/api-handler.ts:83-90\` | \`ApiError\` 以外の例外を \`{error: "Internal server error"}\` 500 に置換。AIService が投げる \`Error\` の本文がレスポンスに乗らない |
| 2 | \`HolidayManagementClient.tsx:220-224\` | \`!res.ok\` の時にレスポンスボディを読まず、固定メッセージ \`t.error\` を表示 |

## Summary

- 祝日生成 route で \`AIService.generate\` と JSON 解析失敗を try/catch し、\`ApiError.badRequest\` として再 throw。エラー本文（モデル名・消費 token・対処法）がそのままレスポンスに載るようになる。
- \`HolidayManagementClient\` で \`!res.ok\` 時に \`res.json()\` の \`errorJa\` / \`error\` を読み、無い場合のみ \`t.error\` にフォールバック。エラー時は赤、複数行は \`whitespace-pre-line\` で表示。
- 祝日生成 route の単体テスト 5 件を追加（thinking モデル切れ・任意 Error・JSON 解析失敗・バリデーション・正常系）。

## 設計判断

\`apiHandler\` 全体の挙動（500 で内部エラー隠蔽）は変えていない。情報漏洩リスクと既存 API 全体への波及を避けるため、AIエラーは **route 側で明示的に \`ApiError\` 化する** 方針を取った。同パターンは他の AI 呼び出し API（翻訳等）にも将来横展開可能。

## Test plan

- [x] \`pnpm exec jest __tests__/lib/core-modules/ai __tests__/api/ai __tests__/api/calendar\` → 67 件パス（うち新規 5 件）
- [x] \`pnpm exec tsc --noEmit\` → エラーなし
- [ ] LM Studio に thinking モデルをロードして \`/admin/holidays\` から AI 生成 → 「max_tokens を増やすか thinking なしモデルに切り替えてください」というメッセージがダイアログ内に赤字で表示されることを確認
- [ ] 通常モデルで AI 生成 → 緑字で「N 件生成しました」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)