### PR TITLE
fix(access-keys): モジュール粒度の AccessKey 権限がランタイムで無視される問題を修正 (Issue #54)

### DIFF
--- a/apps/web/lib/access-keys.ts
+++ b/apps/web/lib/access-keys.ts
@@ -1,3 +1,4 @@
+import { getAllModules } from "./modules/registry";
 import { prisma } from "./prisma";
 
 /**
@@ -23,6 +24,15 @@ export async function getUserAccessKeyPermissions(
   };
 
   try {
+    // モジュール粒度の権限が含まれる場合に展開するためのモジュール定義（遅延ロード）
+    let modulesCache: Awaited<ReturnType<typeof getAllModules>> | null = null;
+    const ensureModules = async () => {
+      if (!modulesCache) {
+        modulesCache = await getAllModules();
+      }
+      return modulesCache;
+    };
+
     // Get all active Access Keys registered by this user
     const userAccessKeys = await prisma.userAccessKey.findMany({
       where: {
@@ -72,6 +82,22 @@ export async function getUserAccessKeyPermissions(
 
       // 方法2: Phase 2 - AccessKeyPermission からメニューパス・タブを取得
       for (const permission of accessKey.permissions) {
+        // モジュール粒度: moduleId 配下の有効な全メニューパスを展開
+        if (permission.granularity === "module" && permission.moduleId) {
+          const modules = await ensureModules();
+          const mod = modules.find((m) => m.id === permission.moduleId);
+          if (!mod) continue;
+          for (const menu of mod.menus) {
+            if (menu.enabled === false) continue;
+            result.menuPaths.push(menu.path);
+            for (const child of menu.children ?? []) {
+              if (child.enabled === false) continue;
+              result.menuPaths.push(child.path);
+            }
+          }
+          continue;
+        }
+
         if (permission.menuPath) {
           result.menuPaths.push(permission.menuPath);
 

--- a/apps/web/lib/api/api-handler.ts
+++ b/apps/web/lib/api/api-handler.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { checkAccess } from "@/lib/auth/access-checker";
 import { ApiError } from "./api-error";
 import {
+  expandMinimumRole,
   requireAdmin,
   requireAuth,
   requireOneOfRoles,
@@ -16,21 +17,6 @@ type HandlerFn<T = unknown, Ctx = unknown> = (
   context: Ctx,
 ) => Promise<T>;
 
-const ROLE_HIERARCHY: Record<Role, number> = {
-  GUEST: 0,
-  USER: 1,
-  MANAGER: 2,
-  EXECUTIVE: 3,
-  ADMIN: 4,
-};
-
-function expandMinimumRole(minimum: Role): Role[] {
-  const minLevel = ROLE_HIERARCHY[minimum];
-  return (Object.keys(ROLE_HIERARCHY) as Role[]).filter(
-    (role) => ROLE_HIERARCHY[role] >= minLevel,
-  );
-}
-
 interface ApiHandlerOptions {
   /** Require ADMIN role */
   admin?: boolean;
@@ -42,8 +28,21 @@ interface ApiHandlerOptions {
   public?: boolean;
   /**
    * AccessKey 経由でのアクセスを許可するメニューパス。
-   * 設定時は `requiredRole(s)` を満たすか、AccessKey で `menuPath` への
-   * アクセスが許可されていれば通過する。`admin: true` とは併用不可。
+   *
+   * 設定時は `requireAuth()` 後に `checkAccess(session, menuPath, allowedRoles)` を呼び、
+   * 「許可ロールに含まれる」または「AccessKey で当該 menuPath が許可されている」
+   * のいずれかを満たせば通過する。
+   *
+   * 許可ロールの決定順序:
+   * 1. `requiredRoles` が指定されていればそれを使用
+   * 2. `requiredRole`（最低ロール）が指定されていれば階層展開して使用
+   *    （例: `"MANAGER"` → `["MANAGER", "EXECUTIVE", "ADMIN"]`）
+   * 3. いずれも未指定の場合、`checkAccess` のデフォルト `["MANAGER", "ADMIN"]` が適用される
+   *
+   * USER ロール向けの API に `menuPath` を付ける場合は `requiredRoles: ["USER", ...]`
+   * を明示すること。未指定だと USER は AccessKey が無い限り弾かれる。
+   *
+   * `admin: true` とは意味論的に矛盾するため併用不可（ラッパ構築時に Error を throw）。
    */
   menuPath?: string;
   /** HTTP status code for successful response. Default: 200 */

--- a/apps/web/lib/api/api-handler.ts
+++ b/apps/web/lib/api/api-handler.ts
@@ -1,6 +1,7 @@
 import type { Role } from "@prisma/client";
 import type { Session } from "next-auth";
 import { NextResponse } from "next/server";
+import { checkAccess } from "@/lib/auth/access-checker";
 import { ApiError } from "./api-error";
 import {
   requireAdmin,
@@ -15,6 +16,21 @@ type HandlerFn<T = unknown, Ctx = unknown> = (
   context: Ctx,
 ) => Promise<T>;
 
+const ROLE_HIERARCHY: Record<Role, number> = {
+  GUEST: 0,
+  USER: 1,
+  MANAGER: 2,
+  EXECUTIVE: 3,
+  ADMIN: 4,
+};
+
+function expandMinimumRole(minimum: Role): Role[] {
+  const minLevel = ROLE_HIERARCHY[minimum];
+  return (Object.keys(ROLE_HIERARCHY) as Role[]).filter(
+    (role) => ROLE_HIERARCHY[role] >= minLevel,
+  );
+}
+
 interface ApiHandlerOptions {
   /** Require ADMIN role */
   admin?: boolean;
@@ -24,6 +40,12 @@ interface ApiHandlerOptions {
   requiredRoles?: Role[];
   /** Allow unauthenticated access (e.g., health check). Default: false */
   public?: boolean;
+  /**
+   * AccessKey 経由でのアクセスを許可するメニューパス。
+   * 設定時は `requiredRole(s)` を満たすか、AccessKey で `menuPath` への
+   * アクセスが許可されていれば通過する。`admin: true` とは併用不可。
+   */
+  menuPath?: string;
   /** HTTP status code for successful response. Default: 200 */
   successStatus?: number;
 }
@@ -53,6 +75,14 @@ export function apiHandler<T, Ctx = unknown>(
   handler: HandlerFn<T, Ctx>,
   options: ApiHandlerOptions = {},
 ): (request: Request, context?: Ctx) => Promise<NextResponse> {
+  if (options.menuPath && options.admin) {
+    throw new Error(
+      "apiHandler: `menuPath` cannot be combined with `admin: true`. " +
+        "Use `requiredRoles: ['ADMIN']` with `menuPath` to allow AccessKey fallback, " +
+        "or drop `menuPath` for strict ADMIN-only access.",
+    );
+  }
+
   return async (request: Request, context?: Ctx) => {
     try {
       let session: Session;
@@ -61,6 +91,22 @@ export function apiHandler<T, Ctx = unknown>(
         // Public endpoints still try to get session but don't require it
         const { auth } = await import("@/auth");
         session = (await auth()) as Session;
+      } else if (options.menuPath) {
+        // AccessKey フォールバックあり: 認証必須、ロール/AccessKey のいずれかで許可
+        session = await requireAuth();
+        const allowedRoles =
+          options.requiredRoles ??
+          (options.requiredRole
+            ? expandMinimumRole(options.requiredRole)
+            : undefined);
+        const allowed = await checkAccess(
+          session,
+          options.menuPath,
+          allowedRoles,
+        );
+        if (!allowed) {
+          throw ApiError.unauthorized();
+        }
       } else if (options.admin) {
         session = await requireAdmin();
       } else if (options.requiredRoles) {

--- a/apps/web/lib/api/auth-guard.ts
+++ b/apps/web/lib/api/auth-guard.ts
@@ -25,13 +25,29 @@ export async function requireAdmin(): Promise<Session> {
   return session;
 }
 
-const ROLE_HIERARCHY: Record<Role, number> = {
+/**
+ * ロール階層の数値マッピング。値が大きいほど権限が強い。
+ * 階層判定（最低ロール以上か）や `expandMinimumRole` などで利用する。
+ */
+export const ROLE_HIERARCHY: Record<Role, number> = {
   GUEST: 0,
   USER: 1,
   MANAGER: 2,
   EXECUTIVE: 3,
   ADMIN: 4,
 };
+
+/**
+ * 指定された最低ロール以上のロール一覧を返す。
+ *
+ * 例: `expandMinimumRole("MANAGER")` → `["MANAGER", "EXECUTIVE", "ADMIN"]`
+ */
+export function expandMinimumRole(minimum: Role): Role[] {
+  const minLevel = ROLE_HIERARCHY[minimum];
+  return (Object.keys(ROLE_HIERARCHY) as Role[]).filter(
+    (role) => ROLE_HIERARCHY[role] >= minLevel,
+  );
+}
 
 /**
  * Require a minimum role level. Throws ApiError if insufficient.

--- a/apps/web/lib/auth/access-checker.ts
+++ b/apps/web/lib/auth/access-checker.ts
@@ -1,5 +1,5 @@
 import type { Session } from "next-auth";
-import { prisma } from "@/lib/prisma";
+import { getUserAccessKeyPermissions } from "@/lib/access-keys";
 
 /**
  * ユーザが特定のメニューパスにアクセスする権限があるかチェックする
@@ -7,6 +7,10 @@ import { prisma } from "@/lib/prisma";
  * 以下の条件のいずれかを満たす場合、アクセスを許可：
  * 1. ユーザのロールが指定されたrolesに含まれる
  * 2. ユーザが有効なアクセスキーを持ち、そのアクセスキーがmenuPathへのアクセスを許可している
+ *
+ * 判定基準は `getUserAccessKeyPermissions` に委譲しているため、サイドバー表示と
+ * API ゲートでの判定（モジュール粒度の展開、system-delegation キーの TTL チェック等）が
+ * 同じロジックを通る。
  *
  * @param session - NextAuthのセッション
  * @param menuPath - アクセスしようとしているメニューのパス（例: "/analytics"）
@@ -28,75 +32,15 @@ export async function checkAccess(
     return true;
   }
 
-  // 2. アクセスキーチェック
+  // 2. アクセスキーチェック（モジュール粒度の展開もここで行われる）
   try {
-    const userId = session.user.id;
-
-    const userAccessKeys = await prisma.userAccessKey.findMany({
-      where: {
-        userId,
-      },
-      include: {
-        accessKey: {
-          include: {
-            permissions: {
-              include: {
-                permission: true,
-              },
-            },
-          },
-        },
-      },
-    });
-
-    // 有効なアクセスキーを確認
-    for (const uak of userAccessKeys) {
-      const ak = uak.accessKey;
-
-      // アクセスキーが有効かチェック
-      if (!ak.isActive || new Date(ak.expiresAt) < new Date()) {
-        continue;
-      }
-
-      // 方法1: AccessKey.menuPaths (JSON) からチェック
-      if (ak.menuPaths) {
-        try {
-          const menuPaths = JSON.parse(ak.menuPaths) as string[];
-          if (menuPaths.includes(menuPath)) {
-            return true;
-          }
-        } catch {
-          // JSON パースエラーは無視
-        }
-      }
-
-      // 方法2: AccessKeyPermission からチェック
-      for (const akp of ak.permissions) {
-        // 新しい粒度システム（Phase 2）
-        if (akp.menuPath) {
-          // menuPath が直接設定されている場合
-          if (akp.menuPath === menuPath) {
-            return true;
-          }
-          // モジュールレベルの権限の場合、配下の全メニューにアクセス可能
-          if (akp.granularity === "module" && akp.moduleId) {
-            // TODO: モジュールIDからメニューパスを検証するロジックを追加
-            return true;
-          }
-        }
-        // 後方互換性：旧 permission リレーション経由
-        else if (akp.permission?.menuPath === menuPath) {
-          return true;
-        }
-      }
-    }
+    const permissions = await getUserAccessKeyPermissions(session.user.id);
+    return permissions.menuPaths.includes(menuPath);
   } catch (error) {
     console.error(
       "[checkAccess] Error checking access key permissions:",
       error,
     );
-    // エラーが発生してもロールチェックは済んでいるので、falseを返す
+    return false;
   }
-
-  return false;
 }


### PR DESCRIPTION
## Summary

Issue #54 で報告された AccessKey 粒度判定の不整合（モジュール粒度がランタイムで実質的に無視されるバグ 2 件）と、AccessKey 経由ユーザを API ゲートで通すための `apiHandler.menuPath` 機能不足を修正します。

Closes #54

## 変更内容

### バグ1: `getUserAccessKeyPermissions` がモジュール粒度をスキップ (`apps/web/lib/access-keys.ts`)

- `if (permission.menuPath)` ガードにより `menuPath: null` のモジュール粒度権限（`granularity: "module"`, `moduleId: <id>`）が完全スキップされていた
- → `granularity === "module"` の場合に `moduleId` 配下の有効な全メニュー（および `children`）の `path` を展開するよう変更
- `enabled === false` のメニュー／子メニューは除外し、DB の `menu_enabled_*` オーバーライドにも追従

### バグ2: `checkAccess` の到達不能ブランチ + TODO 過剰許可 (`apps/web/lib/auth/access-checker.ts`)

- バグ1 と同型のネストガードで `granularity === "module"` 分岐が `if (akp.menuPath)` の内側にあり到達不能
- `TODO: モジュールIDからメニューパスを検証するロジックを追加` も未実装で、もしネストを単純に外すと `moduleId` と要求 `menuPath` の所属検証なく `return true` する過剰許可状態
- → `getUserAccessKeyPermissions` に委譲する形にリファクタし、判定基準を一元化（バグ1 修正で `moduleId → menuPath` 展開が正しく行われるため、ここでは `menuPaths.includes(menuPath)` で済む）
- 副次的に、system-delegation キー（`createdBy: "system"` + 12h TTL）の期限チェックがサイドバー判定（`access-keys.ts`）には存在し API ゲート判定（`access-checker.ts`）には欠落していた件も解消

### 機能追加: `apiHandler` に `menuPath` オプション (`apps/web/lib/api/api-handler.ts`)

- `ApiHandlerOptions.menuPath` を追加。設定時は `requireAuth()` 後に `checkAccess(session, menuPath, allowedRoles)` を呼び、ロール または AccessKey のいずれかで通過
- `menuPath` と `admin: true` の併用は意味論的に矛盾するため、ラッパ構築時に `throw new Error(...)` で早期検知
- `requiredRole`（最低ロール）は `ROLE_HIERARCHY` で展開してから `checkAccess` に渡す（例: `requiredRole: "MANAGER"` → `["MANAGER", "EXECUTIVE", "ADMIN"]`）
- 既存挙動への破壊的変更なし（opt-in）

\`\`\`ts
// 使用例
export const GET = apiHandler(
  async () => { ... },
  {
    requiredRoles: ["ADMIN"] as Role[],
    menuPath: "/backoffice/something",  // ← AccessKey フォールバックを有効化
  },
);
\`\`\`

## Test plan

- [x] `pnpm exec tsc --noEmit` — 通過
- [x] `pnpm test`（全テスト 327 件）— 通過
- [ ] サイドバーの AccessKey 経由メニュー表示（モジュール粒度キーで対象モジュール配下のメニューが出ること）
- [ ] API ゲート側で `checkAccess` が同じ menuPath を許可すること
- [ ] `apiHandler({ menuPath, admin: true })` が起動時にエラーで弾かれること
- [ ] system-delegation キー（12h TTL）が期限切れ後にサイドバーと API 両方で拒否されること

## 参考

- Issue: #54
- 報告元フォークの参考 PR: https://github.com/ted-occ/ted-box3/pull/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)