### PR TITLE
fix(modules): getAllModules で menu.children にも enabled/order オーバーライドを適用 (Issue #56)

### DIFF
--- a/apps/web/lib/modules/registry.tsx
+++ b/apps/web/lib/modules/registry.tsx
@@ -124,6 +124,11 @@ export async function getAllModules(): Promise<AppModule[]> {
         ...menu,
         order: menuOrderOverrides[menu.id] ?? menu.order,
         enabled: menuEnabledOverrides[menu.id] ?? menu.enabled,
+        children: menu.children?.map((child) => ({
+          ...child,
+          order: menuOrderOverrides[child.id] ?? child.order,
+          enabled: menuEnabledOverrides[child.id] ?? child.enabled,
+        })),
       })),
     }));
 }


### PR DESCRIPTION
## Summary

`getAllModules()` が DB の `menu_enabled_*` / `menu_order_*` SystemSetting オーバーライドをトップレベルの `menus` にのみ適用し、`menus[].children` には適用していなかった既存の制限を修正します。

Closes #56

## 背景

PR #55 のレビュー指摘で発見された既存の制限。`AppMenu` の型は `children?: AppMenu[]` をサポートしているが、`getAllModules()` の `map` で children を素通りさせていたため、DB で子メニューを無効化（`menu_enabled_<childId>: "false"`）してもサイドバー描画や AccessKey 経由アクセスで有効扱いされる。

PR #55 で追加した AccessKey のモジュール粒度展開で `menu.children` を辿る処理:

```ts
// apps/web/lib/access-keys.ts (PR #55 で追加)
for (const child of menu.children ?? []) {
  if (child.enabled === false) continue;  // ← child.enabled は静的値のまま
  result.menuPaths.push(child.path);
}
```

`child.enabled` がモジュール定義の静的値を参照していたため、DB オーバーライドが反映されない状態だった。

## 修正内容

`apps/web/lib/modules/registry.tsx` の `getAllModules()` で、`children` にも親メニューと同じオーバーライド処理を適用:

```ts
menus: module.menus.map((menu) => ({
  ...menu,
  order: menuOrderOverrides[menu.id] ?? menu.order,
  enabled: menuEnabledOverrides[menu.id] ?? menu.enabled,
  children: menu.children?.map((child) => ({
    ...child,
    order: menuOrderOverrides[child.id] ?? child.order,
    enabled: menuEnabledOverrides[child.id] ?? child.enabled,
  })),
})),
```

## 影響範囲

- 現時点でモジュール定義で `children` を使っているメニューは存在しない（コアモジュール、内部アドオン、キオスク、外部アドオンを確認済み）ため**実害は出ていない**。
- 将来 children を使うモジュールが追加された際の暗黙バグを未然に防ぐ予防的修正。

## Test plan

- [x] `pnpm exec tsc --noEmit` — 通過
- [x] `pnpm test`（327 件）— 通過
- [ ] 動作確認は children を持つモジュールが存在しないため省略

## 参考

- 関連: PR #55, Issue #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)