### PR TITLE
fix(auth): ログインのレート制限を「失敗のみカウント・成功でリセット」に変更 (Issue #58)

### DIFF
--- a/apps/web/__tests__/lib/services/rate-limiter.test.ts
+++ b/apps/web/__tests__/lib/services/rate-limiter.test.ts
@@ -3,7 +3,7 @@
  *
  * ログイン系レート制限の定石「失敗のみカウントし、成功でリセット」を
  * 実現するための関数群を検証する。
- * - isRateLimited: カウントを増やさず判定のみ（peek）
+ * - peekRateLimit: カウントを増やさず判定のみ（peek）
  * - recordFailedAttempt: 失敗時のみ1件記録
  * - resetRateLimit: 成功時にキーをクリア
  * 既存 checkRateLimit は他ルート互換のため挙動を変えない。
@@ -11,7 +11,7 @@
 
 import {
   checkRateLimit,
-  isRateLimited,
+  peekRateLimit,
   recordFailedAttempt,
   resetRateLimit,
 } from "@/lib/services/rate-limiter";
@@ -23,11 +23,11 @@ describe("rate-limiter: peek/record/reset (Issue #58)", () => {
   // テストごとに一意なキーを使い、モジュールレベル store の干渉を避ける
   const nextKey = () => `test:${Date.now()}:${counter++}`;
 
-  describe("isRateLimited", () => {
+  describe("peekRateLimit", () => {
     it("判定だけではカウントを消費しない（何回呼んでも allowed のまま）", () => {
       const key = nextKey();
       for (let i = 0; i < 100; i++) {
-        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+        expect(peekRateLimit(key, 10, WINDOW).allowed).toBe(true);
       }
     });
 
@@ -36,7 +36,7 @@ describe("rate-limiter: peek/record/reset (Issue #58)", () => {
       for (let i = 0; i < 10; i++) {
         recordFailedAttempt(key, WINDOW);
       }
-      const r = isRateLimited(key, 10, WINDOW);
+      const r = peekRateLimit(key, 10, WINDOW);
       expect(r.allowed).toBe(false);
       expect(r.remaining).toBe(0);
     });
@@ -45,7 +45,7 @@ describe("rate-limiter: peek/record/reset (Issue #58)", () => {
       const key = nextKey();
       recordFailedAttempt(key, WINDOW);
       recordFailedAttempt(key, WINDOW);
-      const r = isRateLimited(key, 10, WINDOW);
+      const r = peekRateLimit(key, 10, WINDOW);
       expect(r.allowed).toBe(true);
       expect(r.remaining).toBe(8);
     });
@@ -54,12 +54,12 @@ describe("rate-limiter: peek/record/reset (Issue #58)", () => {
   describe("recordFailedAttempt", () => {
     it("失敗を記録するたびにカウントが増える", () => {
       const key = nextKey();
-      expect(isRateLimited(key, 3, WINDOW).remaining).toBe(3);
+      expect(peekRateLimit(key, 3, WINDOW).remaining).toBe(3);
       recordFailedAttempt(key, WINDOW);
-      expect(isRateLimited(key, 3, WINDOW).remaining).toBe(2);
+      expect(peekRateLimit(key, 3, WINDOW).remaining).toBe(2);
       recordFailedAttempt(key, WINDOW);
       recordFailedAttempt(key, WINDOW);
-      expect(isRateLimited(key, 3, WINDOW).allowed).toBe(false);
+      expect(peekRateLimit(key, 3, WINDOW).allowed).toBe(false);
     });
   });
 
@@ -67,30 +67,30 @@ describe("rate-limiter: peek/record/reset (Issue #58)", () => {
     it("成功時にキーをクリアするとカウントが0に戻る", () => {
       const key = nextKey();
       for (let i = 0; i < 9; i++) recordFailedAttempt(key, WINDOW);
-      expect(isRateLimited(key, 10, WINDOW).remaining).toBe(1);
+      expect(peekRateLimit(key, 10, WINDOW).remaining).toBe(1);
       resetRateLimit(key);
-      expect(isRateLimited(key, 10, WINDOW).remaining).toBe(10);
-      expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+      expect(peekRateLimit(key, 10, WINDOW).remaining).toBe(10);
+      expect(peekRateLimit(key, 10, WINDOW).allowed).toBe(true);
     });
   });
 
   describe("成功はカウントしない（Issue #58 の本質）", () => {
-    it("isRateLimited を 1000 回呼んでも失敗0件ならブロックされない", () => {
+    it("peekRateLimit を 1000 回呼んでも失敗0件ならブロックされない", () => {
       const key = nextKey();
       for (let i = 0; i < 1000; i++) {
-        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+        expect(peekRateLimit(key, 10, WINDOW).allowed).toBe(true);
       }
     });
 
     it("失敗9回→成功(reset)→以降の判定はブロックされない", () => {
       const key = nextKey();
       for (let i = 0; i < 9; i++) {
-        if (!isRateLimited(key, 10, WINDOW).allowed) break;
+        if (!peekRateLimit(key, 10, WINDOW).allowed) break;
         recordFailedAttempt(key, WINDOW);
       }
       resetRateLimit(key);
       for (let i = 0; i < 50; i++) {
-        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+        expect(peekRateLimit(key, 10, WINDOW).allowed).toBe(true);
       }
     });
   });

--- a/apps/web/__tests__/lib/services/rate-limiter.test.ts
+++ b/apps/web/__tests__/lib/services/rate-limiter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * rate-limiter の peek / record / reset テスト (Issue #58)
+ *
+ * ログイン系レート制限の定石「失敗のみカウントし、成功でリセット」を
+ * 実現するための関数群を検証する。
+ * - isRateLimited: カウントを増やさず判定のみ（peek）
+ * - recordFailedAttempt: 失敗時のみ1件記録
+ * - resetRateLimit: 成功時にキーをクリア
+ * 既存 checkRateLimit は他ルート互換のため挙動を変えない。
+ */
+
+import {
+  checkRateLimit,
+  isRateLimited,
+  recordFailedAttempt,
+  resetRateLimit,
+} from "@/lib/services/rate-limiter";
+
+const WINDOW = 15 * 60 * 1000;
+
+describe("rate-limiter: peek/record/reset (Issue #58)", () => {
+  let counter = 0;
+  // テストごとに一意なキーを使い、モジュールレベル store の干渉を避ける
+  const nextKey = () => `test:${Date.now()}:${counter++}`;
+
+  describe("isRateLimited", () => {
+    it("判定だけではカウントを消費しない（何回呼んでも allowed のまま）", () => {
+      const key = nextKey();
+      for (let i = 0; i < 100; i++) {
+        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+      }
+    });
+
+    it("記録された失敗が上限に達すると allowed=false を返す", () => {
+      const key = nextKey();
+      for (let i = 0; i < 10; i++) {
+        recordFailedAttempt(key, WINDOW);
+      }
+      const r = isRateLimited(key, 10, WINDOW);
+      expect(r.allowed).toBe(false);
+      expect(r.remaining).toBe(0);
+    });
+
+    it("上限未満なら allowed=true で残り回数を返す", () => {
+      const key = nextKey();
+      recordFailedAttempt(key, WINDOW);
+      recordFailedAttempt(key, WINDOW);
+      const r = isRateLimited(key, 10, WINDOW);
+      expect(r.allowed).toBe(true);
+      expect(r.remaining).toBe(8);
+    });
+  });
+
+  describe("recordFailedAttempt", () => {
+    it("失敗を記録するたびにカウントが増える", () => {
+      const key = nextKey();
+      expect(isRateLimited(key, 3, WINDOW).remaining).toBe(3);
+      recordFailedAttempt(key, WINDOW);
+      expect(isRateLimited(key, 3, WINDOW).remaining).toBe(2);
+      recordFailedAttempt(key, WINDOW);
+      recordFailedAttempt(key, WINDOW);
+      expect(isRateLimited(key, 3, WINDOW).allowed).toBe(false);
+    });
+  });
+
+  describe("resetRateLimit", () => {
+    it("成功時にキーをクリアするとカウントが0に戻る", () => {
+      const key = nextKey();
+      for (let i = 0; i < 9; i++) recordFailedAttempt(key, WINDOW);
+      expect(isRateLimited(key, 10, WINDOW).remaining).toBe(1);
+      resetRateLimit(key);
+      expect(isRateLimited(key, 10, WINDOW).remaining).toBe(10);
+      expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+    });
+  });
+
+  describe("成功はカウントしない（Issue #58 の本質）", () => {
+    it("isRateLimited を 1000 回呼んでも失敗0件ならブロックされない", () => {
+      const key = nextKey();
+      for (let i = 0; i < 1000; i++) {
+        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+      }
+    });
+
+    it("失敗9回→成功(reset)→以降の判定はブロックされない", () => {
+      const key = nextKey();
+      for (let i = 0; i < 9; i++) {
+        if (!isRateLimited(key, 10, WINDOW).allowed) break;
+        recordFailedAttempt(key, WINDOW);
+      }
+      resetRateLimit(key);
+      for (let i = 0; i < 50; i++) {
+        expect(isRateLimited(key, 10, WINDOW).allowed).toBe(true);
+      }
+    });
+  });
+
+  describe("既存 checkRateLimit の後方互換", () => {
+    it("従来どおり呼び出しごとにカウントを消費する", () => {
+      const key = nextKey();
+      for (let i = 0; i < 5; i++) {
+        expect(checkRateLimit(key, 5, WINDOW).allowed).toBe(true);
+      }
+      expect(checkRateLimit(key, 5, WINDOW).allowed).toBe(false);
+    });
+  });
+});

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { AuditService } from "@/lib/services/audit-service";
 import {
   getClientIp,
-  isRateLimited,
+  peekRateLimit,
   recordFailedAttempt,
   resetRateLimit,
 } from "@/lib/services/rate-limiter";
@@ -39,7 +39,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // Rate limit: 失敗 10 回 / 15 分 / IP（成功はカウントしない・Issue #58）
         const ip = getClientIp(request);
         const rateLimitKey = `login:${ip}`;
-        if (!isRateLimited(rateLimitKey, 10, 15 * 60 * 1000).allowed) {
+        const WINDOW_MS = 15 * 60 * 1000;
+        if (!peekRateLimit(rateLimitKey, 10, WINDOW_MS).allowed) {
           // レート超過も監査ログに残す（原因追跡のため）
           await AuditService.log({
             action: "LOGIN_FAILURE",
@@ -59,7 +60,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           });
 
           if (!user?.password) {
-            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
+            recordFailedAttempt(rateLimitKey, WINDOW_MS);
             // ログイン失敗を監査ログに記録
             await AuditService.log({
               action: "LOGIN_FAILURE",
@@ -79,7 +80,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           );
 
           if (!isValid) {
-            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
+            recordFailedAttempt(rateLimitKey, WINDOW_MS);
             await AuditService.log({
               action: "LOGIN_FAILURE",
               category: "AUTH",
@@ -98,7 +99,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             user.passwordExpiresAt &&
             new Date() > new Date(user.passwordExpiresAt)
           ) {
-            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
+            recordFailedAttempt(rateLimitKey, WINDOW_MS);
             await AuditService.log({
               action: "LOGIN_FAILURE",
               category: "AUTH",
@@ -155,7 +156,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         const ip = getClientIp(request);
         const rateLimitKey = `webauthn:${ip}`;
         const WINDOW_MS = 15 * 60 * 1000;
-        if (!isRateLimited(rateLimitKey, 20, WINDOW_MS).allowed) {
+        if (!peekRateLimit(rateLimitKey, 20, WINDOW_MS).allowed) {
           await AuditService.log({
             action: "WEBAUTHN_AUTHENTICATE_FAILURE",
             category: "AUTH",
@@ -167,6 +168,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         const raw = creds?.assertion;
         if (typeof raw !== "string" || raw.length === 0) {
           recordFailedAttempt(rateLimitKey, WINDOW_MS);
+          await AuditService.log({
+            action: "WEBAUTHN_AUTHENTICATE_FAILURE",
+            category: "AUTH",
+            details: { reason: "Missing or empty assertion" },
+          }).catch(() => {});
           return null;
         }
 
@@ -175,6 +181,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           assertion = JSON.parse(raw) as AuthenticationResponseJSON;
         } catch {
           recordFailedAttempt(rateLimitKey, WINDOW_MS);
+          await AuditService.log({
+            action: "WEBAUTHN_AUTHENTICATE_FAILURE",
+            category: "AUTH",
+            details: { reason: "Malformed assertion JSON" },
+          }).catch(() => {});
           return null;
         }
 

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -5,7 +5,12 @@ import Credentials from "next-auth/providers/credentials";
 import { authConfig } from "@/auth.config";
 import { prisma } from "@/lib/prisma";
 import { AuditService } from "@/lib/services/audit-service";
-import { checkRateLimit, getClientIp } from "@/lib/services/rate-limiter";
+import {
+  getClientIp,
+  isRateLimited,
+  recordFailedAttempt,
+  resetRateLimit,
+} from "@/lib/services/rate-limiter";
 import {
   clearChallenge,
   getChallenge,
@@ -31,10 +36,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           return null;
         }
 
-        // Rate limit: 10 attempts per 15 minutes per IP
+        // Rate limit: 失敗 10 回 / 15 分 / IP（成功はカウントしない・Issue #58）
         const ip = getClientIp(request);
-        const rateLimit = checkRateLimit(`login:${ip}`, 10, 15 * 60 * 1000);
-        if (!rateLimit.allowed) {
+        const rateLimitKey = `login:${ip}`;
+        if (!isRateLimited(rateLimitKey, 10, 15 * 60 * 1000).allowed) {
+          // レート超過も監査ログに残す（原因追跡のため）
+          await AuditService.log({
+            action: "LOGIN_FAILURE",
+            category: "AUTH",
+            details: {
+              email: credentials.email,
+              provider: "credentials",
+              reason: "Rate limit exceeded",
+            },
+          }).catch(() => {});
           throw new Error("Too many login attempts. Please try again later.");
         }
 
@@ -44,6 +59,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           });
 
           if (!user?.password) {
+            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
             // ログイン失敗を監査ログに記録
             await AuditService.log({
               action: "LOGIN_FAILURE",
@@ -63,6 +79,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           );
 
           if (!isValid) {
+            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
             await AuditService.log({
               action: "LOGIN_FAILURE",
               category: "AUTH",
@@ -81,6 +98,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             user.passwordExpiresAt &&
             new Date() > new Date(user.passwordExpiresAt)
           ) {
+            recordFailedAttempt(rateLimitKey, 15 * 60 * 1000);
             await AuditService.log({
               action: "LOGIN_FAILURE",
               category: "AUTH",
@@ -92,6 +110,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             }).catch(() => {});
             return null;
           }
+
+          // 認証成功: レート制限カウントをリセット
+          resetRateLimit(rateLimitKey);
 
           // 最終サインイン日時を更新
           await prisma.user.update({
@@ -130,14 +151,22 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         assertion: { label: "Assertion", type: "text" },
       },
       async authorize(creds, request) {
+        // Rate limit: 失敗 20 回 / 15 分 / IP（成功はカウントしない・Issue #58）
         const ip = getClientIp(request);
-        const rateLimit = checkRateLimit(`webauthn:${ip}`, 20, 15 * 60 * 1000);
-        if (!rateLimit.allowed) {
+        const rateLimitKey = `webauthn:${ip}`;
+        const WINDOW_MS = 15 * 60 * 1000;
+        if (!isRateLimited(rateLimitKey, 20, WINDOW_MS).allowed) {
+          await AuditService.log({
+            action: "WEBAUTHN_AUTHENTICATE_FAILURE",
+            category: "AUTH",
+            details: { reason: "Rate limit exceeded" },
+          }).catch(() => {});
           throw new Error("Too many login attempts. Please try again later.");
         }
 
         const raw = creds?.assertion;
         if (typeof raw !== "string" || raw.length === 0) {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           return null;
         }
 
@@ -145,11 +174,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         try {
           assertion = JSON.parse(raw) as AuthenticationResponseJSON;
         } catch {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           return null;
         }
 
         const ctx = await getChallenge();
         if (!ctx || ctx.kind !== "authentication") {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           await clearChallenge();
           return null;
         }
@@ -158,6 +189,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           assertion.id,
         );
         if (!stored) {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           await clearChallenge();
           await AuditService.log({
             action: "WEBAUTHN_AUTHENTICATE_FAILURE",
@@ -183,6 +215,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           );
           await CredentialService.updateCounter(stored.id, newCounter);
         } catch (error) {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           await clearChallenge();
           await AuditService.log({
             action: "WEBAUTHN_AUTHENTICATE_FAILURE",
@@ -201,9 +234,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           where: { id: stored.userId },
         });
         if (!user) {
+          recordFailedAttempt(rateLimitKey, WINDOW_MS);
           await clearChallenge();
           return null;
         }
+
+        // 認証成功: レート制限カウントをリセット
+        resetRateLimit(rateLimitKey);
 
         await prisma.user.update({
           where: { id: user.id },

--- a/apps/web/lib/services/rate-limiter.ts
+++ b/apps/web/lib/services/rate-limiter.ts
@@ -80,6 +80,83 @@ export function checkRateLimit(
 }
 
 /**
+ * Peek the rate limit state for a key WITHOUT consuming a slot.
+ *
+ * ログイン系で「成功もカウントしてしまう」問題 (Issue #58) を避けるため、
+ * 入口での判定はこの関数で行い、カウントは {@link recordFailedAttempt}
+ * （失敗時のみ）で増やす。
+ *
+ * @param key - Unique identifier (e.g., IP address, user ID)
+ * @param maxRequests - Maximum number of failed attempts allowed in the window
+ * @param windowMs - Time window in milliseconds
+ */
+export function isRateLimited(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+): RateLimitResult {
+  cleanup(windowMs);
+
+  const now = Date.now();
+  const cutoff = now - windowMs;
+  const entry = store.get(key);
+
+  if (!entry) {
+    return { allowed: true, remaining: maxRequests, resetMs: windowMs };
+  }
+
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+  if (entry.timestamps.length >= maxRequests) {
+    const oldestInWindow = entry.timestamps[0];
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs: oldestInWindow + windowMs - now,
+    };
+  }
+
+  return {
+    allowed: true,
+    remaining: maxRequests - entry.timestamps.length,
+    resetMs: windowMs,
+  };
+}
+
+/**
+ * Record a single failed attempt for a key.
+ *
+ * 認証失敗（ユーザー無し／パスワード不一致など）の経路でのみ呼ぶ。
+ *
+ * @param key - Unique identifier (e.g., IP address, user ID)
+ * @param windowMs - Time window in milliseconds (古い記録の刈り込みに使用)
+ */
+export function recordFailedAttempt(key: string, windowMs: number): void {
+  cleanup(windowMs);
+
+  const now = Date.now();
+  const cutoff = now - windowMs;
+
+  let entry = store.get(key);
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+  entry.timestamps.push(now);
+}
+
+/**
+ * Clear all recorded attempts for a key.
+ *
+ * 認証成功時に呼び、その IP の失敗カウントをリセットする。
+ */
+export function resetRateLimit(key: string): void {
+  store.delete(key);
+}
+
+/**
  * Get client IP from request headers.
  * Supports x-forwarded-for header for reverse proxy setups.
  */

--- a/apps/web/lib/services/rate-limiter.ts
+++ b/apps/web/lib/services/rate-limiter.ts
@@ -84,13 +84,14 @@ export function checkRateLimit(
  *
  * ログイン系で「成功もカウントしてしまう」問題 (Issue #58) を避けるため、
  * 入口での判定はこの関数で行い、カウントは {@link recordFailedAttempt}
- * （失敗時のみ）で増やす。
+ * （失敗時のみ）で増やす。戻り値は {@link checkRateLimit} と同じ
+ * {@link RateLimitResult}（`.allowed` で判定）。
  *
  * @param key - Unique identifier (e.g., IP address, user ID)
  * @param maxRequests - Maximum number of failed attempts allowed in the window
  * @param windowMs - Time window in milliseconds
  */
-export function isRateLimited(
+export function peekRateLimit(
   key: string,
   maxRequests: number,
   windowMs: number,


### PR DESCRIPTION
## 概要

Issue #58 の修正。`auth.ts` のレート制限が**成功ログインもカウント**するため、同一IP（リバースプロキシ配下 / 開発環境の `unknown` バケット）から15分に10回ログインすると、11回目以降の正規ユーザーが認証失敗していた。

## 変更内容

- `lib/services/rate-limiter.ts`
  - `isRateLimited`（カウントを増やさない peek 判定）
  - `recordFailedAttempt`（失敗時のみ1件記録）
  - `resetRateLimit`（成功時にキーをクリア）
  - 既存 `checkRateLimit` は他ルート互換のため**温存**（挙動不変）
- `auth.ts`
  - credentials / webauthn とも、入口は `isRateLimited` で判定のみ
  - 失敗3経路（ユーザー無し／パスワード不一致／仮パスワード期限切れ）＋ webauthn 各失敗経路で `recordFailedAttempt`
  - 認証成功時に `resetRateLimit`
  - レート超過時も `LOGIN_FAILURE` / `WEBAUTHN_AUTHENTICATE_FAILURE`（reason: Rate limit exceeded）を監査ログに記録（throw を try より前から移動し、ログ欠落を解消）

挙動: 連続「失敗」10回/15分（webauthn は20回）のみでレート制限発動。成功サインインは無制限。

## テスト

- `__tests__/lib/services/rate-limiter.test.ts` を新規追加（peek/record/reset、成功非カウント、後方互換）
- `tsc --noEmit` / Biome クリーン、関連テスト 56 件 green

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)